### PR TITLE
Change Pipeline Windows VM Image to windows-2019 and Fix Exception Unit Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated pipeline Windows VM image to windows-2019
+
 ## [0.4.0] - 2020-03-09
 
 ### Added

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ stages:
               summaryFileLocation: 'output/testResults/CodeCov*.xml'
       - job: test_windows_core
         pool:
-          vmImage: 'win1803'
+          vmImage: 'windows-2019'
         steps:
           - task: DownloadBuildArtifacts@0
             inputs:
@@ -102,7 +102,7 @@ stages:
               summaryFileLocation: 'output/testResults/CodeCov*.xml'
       - job: test_windows_ps
         pool:
-          vmImage: 'win1803'
+          vmImage: 'windows-2019'
         steps:
           - task: DownloadBuildArtifacts@0
             inputs:

--- a/tests/Unit/Public/New-InvalidArgumentException.Tests.ps1
+++ b/tests/Unit/Public/New-InvalidArgumentException.Tests.ps1
@@ -5,13 +5,17 @@ $ProjectName = ((Get-ChildItem -Path $ProjectPath\*\*.psd1).Where{
     }).BaseName
 
 Import-Module $ProjectName -Force
+
 Describe 'New-InvalidArgumentException' {
     Context 'When calling with both the Message and ArgumentName parameter' {
         It 'Should throw the correct error' {
             $mockErrorMessage = 'Mocked error'
             $mockArgumentName = 'MockArgument'
 
-            { New-InvalidArgumentException -Message $mockErrorMessage -ArgumentName $mockArgumentName } | Should -Throw ('Parameter name: {0}' -f $mockArgumentName)
+            # Wildcard processing needed to handle differing Powershell 5/6/7 exception output
+            { New-InvalidArgumentException -Message $mockErrorMessage -ArgumentName $mockArgumentName } |
+                Should -Throw -PassThru | Select-Object -ExpandProperty Exception |
+                    Should -BeLike ('{0}*Parameter*{1}*' -f $mockErrorMesssage, $mockArgumentName)
         }
     }
 

--- a/tests/Unit/Public/New-InvalidOperationException.Tests.ps1
+++ b/tests/Unit/Public/New-InvalidOperationException.Tests.ps1
@@ -5,6 +5,7 @@ $ProjectName = ((Get-ChildItem -Path $ProjectPath\*\*.psd1).Where{
     }).BaseName
 
 Import-Module $ProjectName -Force
+
 Describe 'New-InvalidOperationException' {
     Context 'When calling with Message parameter only' {
         It 'Should throw the correct error' {
@@ -20,9 +21,14 @@ Describe 'New-InvalidOperationException' {
             $mockExceptionErrorMessage = 'Mocked exception error message'
 
             $mockException = New-Object -TypeName System.Exception -ArgumentList $mockExceptionErrorMessage
-            $mockErrorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord -ArgumentList $mockException, $null, 'InvalidResult', $null
+            $mockErrorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
+                -ArgumentList $mockException, $null, 'InvalidResult', $null
 
-            { New-InvalidOperationException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should -Throw ('System.InvalidOperationException: {0} ---> System.Exception: {1}' -f $mockErrorMessage, $mockExceptionErrorMessage)
+            # Wildcard processing needed to handle differing Powershell 5/6/7 exception output
+            { New-InvalidOperationException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } |
+                Should -Throw -Passthru | Select-Object -ExpandProperty Exception |
+                 Should -BeLike ('System.Exception: System.InvalidOperationException: {0}*System.Exception: {1}*' -f
+                        $mockErrorMessage, $mockExceptionErrorMessage)
         }
     }
 

--- a/tests/Unit/Public/New-InvalidResultException.Tests.ps1
+++ b/tests/Unit/Public/New-InvalidResultException.Tests.ps1
@@ -21,9 +21,14 @@ Describe 'New-InvalidResultException' {
             $mockExceptionErrorMessage = 'Mocked exception error message'
 
             $mockException = New-Object -TypeName System.Exception -ArgumentList $mockExceptionErrorMessage
-            $mockErrorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord -ArgumentList $mockException, $null, 'InvalidResult', $null
+            $mockErrorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
+                -ArgumentList $mockException, $null, 'InvalidResult', $null
 
-            { New-InvalidResultException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should -Throw ('System.Exception: {0} ---> System.Exception: {1}' -f $mockErrorMessage, $mockExceptionErrorMessage)
+            # Wildcard processing needed to handle differing Powershell 5/6/7 exception output
+            { New-InvalidResultException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } |
+                Should -Throw -Passthru | Select-Object -ExpandProperty Exception |
+                  Should -BeLike ('System.Exception: System.Exception: {0}*System.Exception: {1}*' -f
+                        $mockErrorMessage, $mockExceptionErrorMessage)
         }
     }
 

--- a/tests/Unit/Public/New-ObjectNotFoundException.Tests.ps1
+++ b/tests/Unit/Public/New-ObjectNotFoundException.Tests.ps1
@@ -21,9 +21,13 @@ Describe 'New-ObjectNotFoundException' {
             $mockExceptionErrorMessage = 'Mocked exception error message'
 
             $mockException = New-Object -TypeName System.Exception -ArgumentList $mockExceptionErrorMessage
-            $mockErrorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord -ArgumentList $mockException, $null, 'InvalidResult', $null
+            $mockErrorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
+                -ArgumentList $mockException, $null, 'InvalidResult', $null
 
-            { New-ObjectNotFoundException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should -Throw ('System.Exception: {0} ---> System.Exception: {1}' -f $mockErrorMessage, $mockExceptionErrorMessage)
+            { New-ObjectNotFoundException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } |
+                Should -Throw -Passthru | Select-Object -ExpandProperty Exception |
+                    Should -BeLike ('System.Exception: System.Exception: {0}*System.Exception: {1}*' -f
+                        $mockErrorMessage, $mockExceptionErrorMessage)
         }
     }
 


### PR DESCRIPTION
This PR changes the Windows VM image used in the CI pipeline from 'win1803' to 'windows-2019'. This is because 'win1803' has been deprecated in Azure DevOps.

It also fixes the `New-*Exception` function unit tests to work correctly on PowerShell version 5, 6 and 7.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.common/18)
<!-- Reviewable:end -->
