### PR TITLE
Get-LocalizedData: Add DefaultUICulture Default Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added a default value of `en-US` to the `DefaultUICulture` parameter of the `Get-LocalizedData` function
+  [Issue #33](https://github.com/dsccommunity/DscResource.Common/issues/33).
+
 ## [0.7.1] - 2020-05-02
 
 ### Fixed

--- a/source/Public/Get-LocalizedData.ps1
+++ b/source/Public/Get-LocalizedData.ps1
@@ -139,7 +139,7 @@
 #>
 function Get-LocalizedData
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'DefaultUICulture')]
     param
     (
         [Parameter(Position = 0)]
@@ -166,7 +166,7 @@ function Get-LocalizedData
 
         [Parameter(Position = 1, ParameterSetName = 'DefaultUICulture')]
         [System.String]
-        $DefaultUICulture
+        $DefaultUICulture = 'en-US'
     )
 
     begin


### PR DESCRIPTION
## Pull Request (PR) description

This PR adds a default value of `en-US` to the `DefaultUICulture` parameter of the `Get-LocalizedData` function.

#### This Pull Request (PR) fixes the following issues

- Fixes #33 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.common/34)
<!-- Reviewable:end -->
