### PR TITLE
Get-LocalizedData: Improve on non-English operating systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 
 - `Get-LocalizedData`
-  - Now correct evaluates the default UI culture
+  - Now correctly evaluates the default UI culture
     on non-English operating systems ([issue #50](https://github.com/dsccommunity/DscResource.Common/issues/50).
   - If the LCID 127 is found it will be skipped and instead use the default
     UI culture (which is `'en-US'` unless specified) ([issue #11](https://github.com/dsccommunity/DscResource.Common/issues/11).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   design pattern to evaluate properties in both _Test_ and _Set_ - fixes
   [issue #47](https://github.com/dsccommunity/DscResource.Common/issues/47).
 
+## Fixed
+
+- `Get-LocalizedData`
+  - Now correct evaluates the default UI culture
+    on non-English operating systems ([issue #50](https://github.com/dsccommunity/DscResource.Common/issues/50).
+  - If the LCID 127 is found it will be skipped and instead use the default
+    UI culture (which is `'en-US'` unless specified) ([issue #11](https://github.com/dsccommunity/DscResource.Common/issues/11).
+
 ## [0.9.1] - 2020-07-08
 
 ## Added

--- a/source/Public/Get-LocalizedData.ps1
+++ b/source/Public/Get-LocalizedData.ps1
@@ -212,6 +212,8 @@ function Get-LocalizedData
             #>
             $currentCulture = Get-UICulture
 
+            $evaluateDefaultCulture = $true
+
             <#
                 If the LCID is 127 then use default UI culture instead.
 
@@ -223,10 +225,6 @@ function Get-LocalizedData
                 $PSBoundParameters['UICulture'] = $DefaultUICulture
 
                 $evaluateDefaultCulture = $false
-            }
-            else
-            {
-                $evaluateDefaultCulture = $true
             }
 
             $languageFile = $null

--- a/tests/Unit/Public/Get-LocalizedData.Tests.ps1
+++ b/tests/Unit/Public/Get-LocalizedData.Tests.ps1
@@ -157,7 +157,7 @@ StringKey    = Sträng värde
                 culture when OS has different culture for which no localized strings
                 exist.
             #>
-            Context "When the operating system UI culture does not exist and the default culture have a '.strings.psd1' file" {
+            Context "When the operating system UI culture does not exist and the default culture has a '.strings.psd1' file" {
                 BeforeAll {
                     New-Item -Force -Path 'TestDrive:\en-US' -ItemType Directory
 

--- a/tests/Unit/Public/Get-LocalizedData.Tests.ps1
+++ b/tests/Unit/Public/Get-LocalizedData.Tests.ps1
@@ -198,7 +198,7 @@ StringKey    = String value
                 }
 
                 It 'Should retrieve the data' {
-                    { Get-LocalizedData -DefaultUICulture 'en-US' -BaseDirectory 'TestDrive:\' -Debug -ErrorAction 'Stop' } | Should -Not -Throw
+                    { Get-LocalizedData -DefaultUICulture 'en-US' -BaseDirectory 'TestDrive:\' -ErrorAction 'Stop' } | Should -Not -Throw
                 }
             }
         }

--- a/tests/Unit/Public/Get-LocalizedData.Tests.ps1
+++ b/tests/Unit/Public/Get-LocalizedData.Tests.ps1
@@ -8,7 +8,7 @@ $ProjectName = ((Get-ChildItem -Path $ProjectPath\*\*.psd1).Where{
 Import-Module $ProjectName
 
 InModuleScope $ProjectName {
-    Describe 'Get-LocalizedData' {
+    Describe 'Get-LocalizedData' -Tag 'GetLocalizedData' {
         Context 'When specifying a specific filename' {
             BeforeAll {
                 New-Item -Force -Path 'TestDrive:\ar-SA' -ItemType Directory
@@ -149,6 +149,56 @@ StringKey    = Sträng värde
 
                 It 'Should retrieve the data' {
                     { Import-Module -Name 'TestDrive:\DSC_Resource2.psm1' -ErrorAction 'Stop' } | Should -Not -Throw
+                }
+            }
+
+            <#
+                Regression test for issues loading the *.strings.psd1 from default
+                culture when OS has different culture for which no localized strings
+                exist.
+            #>
+            Context "When the operating system UI culture does not exist and the default culture have a '.strings.psd1' file" {
+                BeforeAll {
+                    New-Item -Force -Path 'TestDrive:\en-US' -ItemType Directory
+
+                    $null = "
+ConvertFrom-StringData @`'
+# sv-SE strings
+StringKey    = String value
+'@
+                    " | Out-File -Force -FilePath 'TestDrive:\en-US\Get-LocalizedData.Tests.strings.psd1'
+
+                    Mock -CommandName Get-UICulture -MockWith {
+                        return @{
+                            Parent                         = @{
+                                Parent                         = $null
+                                LCID                           = '7'
+                                KeyboardLayoutId               = '7'
+                                Name                           = 'de'
+                                IetfLanguageTag                = 'de'
+                                DisplayName                    = 'German'
+                                NativeName                     = 'Deutsch'
+                                EnglishName                    = 'German'
+                                TwoLetterISOLanguageName       = 'de'
+                                ThreeLetterISOLanguageName     = 'deu'
+                                ThreeLetterWindowsLanguageName = 'DEU'
+                            }
+                            LCID                           = '1031'
+                            KeyboardLayoutId               = '1031'
+                            Name                           = 'de-DE'
+                            IetfLanguageTag                = 'de-DE'
+                            DisplayName                    = 'Deutsch (Deutschland)'
+                            NativeName                     = 'Deutsch (Deutschland)'
+                            EnglishName                    = 'German (Germany)'
+                            TwoLetterISOLanguageName       = 'de'
+                            ThreeLetterISOLanguageName     = 'deu'
+                            ThreeLetterWindowsLanguageName = 'DEU'
+                        }
+                    }
+                }
+
+                It 'Should retrieve the data' {
+                    { Get-LocalizedData -DefaultUICulture 'en-US' -BaseDirectory 'TestDrive:\' -Debug -ErrorAction 'Stop' } | Should -Not -Throw
                 }
             }
         }


### PR DESCRIPTION

#### Pull Request (PR) description
- `Get-LocalizedData`
  - Now correct evaluates the default UI culture
    on non-English operating systems ([issue #50](https://github.com/dsccommunity/DscResource.Common/issues/50).
  - If the LCID 127 is found it will be skipped and instead use the default
    UI culture (which is `'en-US'` unless specified) ([issue #11](https://github.com/dsccommunity/DscResource.Common/issues/11).

#### This Pull Request (PR) fixes the following issues

- Fixes #11
- Fixes #50


#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.common/51)
<!-- Reviewable:end -->
