### PR TITLE
Fix False Positive in Test-DscParameterState with Empty Array Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- Correction to `Test-DscParameterState` returning false positive when parameter
+  with an empty array is passed in `DesriedValues` or `CurrentValues` - fixes
+  [issue #53](https://github.com/dsccommunity/DscResource.Common/issues/53).
+
 ## [0.9.2] - 2020-07-22
 
 ### Added

--- a/source/Public/Test-DscParameterState.ps1
+++ b/source/Public/Test-DscParameterState.ps1
@@ -183,7 +183,7 @@ function Test-DscParameterState
             $currentValue = ConvertTo-HashTable -CimInstance $currentValue
         }
 
-        if ($desiredValue)
+        if ($null -ne $desiredValue)
         {
             $desiredType = $desiredValue.GetType()
         }
@@ -194,7 +194,7 @@ function Test-DscParameterState
             }
         }
 
-        if ($currentValue)
+        if ($null -ne $currentValue)
         {
             $currentType = $currentValue.GetType()
         }

--- a/tests/Unit/Public/Test-DscParameterState.Tests.ps1
+++ b/tests/Unit/Public/Test-DscParameterState.Tests.ps1
@@ -524,6 +524,80 @@ InModuleScope $ProjectName {
                     $script:result | Should -BeTrue
                 }
             }
+
+            Context 'When a current value array is empty' {
+                $currentValues = @{
+                    String    = 'a string'
+                    Bool      = $true
+                    Int       = 99
+                    Array     = @('a','b','c')
+                    Hashtable = @{
+                        k1 = 'Test'
+                        k2 = 123
+                        k3 = @()
+                    }
+                }
+
+                $desiredValues = [PSObject] @{
+                    String    = 'a string'
+                    Bool      = $true
+                    Int       = 99
+                    Array     = @()
+                    Hashtable = @{
+                        k1 = 'Test'
+                        k2 = 123
+                        k3 = @()
+                    }
+                }
+
+                It 'Should not throw exception' {
+                    { $script:result = Test-DscParameterState `
+                            -CurrentValues $currentValues `
+                            -DesiredValues $desiredValues `
+                            -Verbose:$verbose } | Should -Not -Throw
+                }
+
+                It 'Should return $false' {
+                    $script:result | Should -BeFalse
+                }
+            }
+
+            Context 'When a desired value array is empty' {
+                $currentValues = @{
+                    String    = 'a string'
+                    Bool      = $true
+                    Int       = 99
+                    Array     = @()
+                    Hashtable = @{
+                        k1 = 'Test'
+                        k2 = 123
+                        k3 = @()
+                    }
+                }
+
+                $desiredValues = [PSObject] @{
+                    String    = 'a string'
+                    Bool      = $true
+                    Int       = 99
+                    Array     = @('a','b','c')
+                    Hashtable = @{
+                        k1 = 'Test'
+                        k2 = 123
+                        k3 = @()
+                    }
+                }
+
+                It 'Should not throw exception' {
+                    { $script:result = Test-DscParameterState `
+                            -CurrentValues $currentValues `
+                            -DesiredValues $desiredValues `
+                            -Verbose:$verbose } | Should -Not -Throw
+                }
+
+                It 'Should return $false' {
+                    $script:result | Should -BeFalse
+                }
+            }
         }
 
         Context 'When testing hashtables' {


### PR DESCRIPTION
#### Pull Request (PR) description

- Correction to `Test-DscParameterState` returning false positive when parameter
  with an empty array is passed in `DesriedValues` or `CurrentValues` - fixes
  [issue #53](https://github.com/dsccommunity/DscResource.Common/issues/53).

#### This Pull Request (PR) fixes the following issues

- Fixes #53

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

@johlju - would you mind reviewing this one when you have time?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.common/54)
<!-- Reviewable:end -->
