### PR TITLE
Removing IncludeDesiredState and IncludeValue parameter in Test-DscParameterState and correct typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The OutPut of Compare-DscParameterState is a collection psobject.
   The properties of psobject are Property,InDesiredState,ExpectedType,ActualType,
   ExpectedValue and ActualValue. The IncludeInDesiredState parameter must be use to
-  add ExceptedValue and ActualValue.
+  add ExeptedValue and ActualValue.
 - Added pester test to test the pscredential object with `Compare-DscParameterState`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Cmdlet Test-DscResourceState is now calling Compare-DscParameterState. Possible breaking change.
+- IncludeInDesiredState and IncludeValue parameters of Compare-DscParameterState
+  are removed in splatting when Test-DscCompareState is called.
 
 ### Fix
 

--- a/source/Public/Compare-DscParameterState.ps1
+++ b/source/Public/Compare-DscParameterState.ps1
@@ -35,8 +35,8 @@
         before doing the comparison.
 
     .PARAMETER IncludeInDesiredState
-        Indicates that result adds the properties in desired state.
-        By default, this command return only the properties in not desired state.
+        Indicates that result adds the properties in the desired state.
+        By default, this command returns only the properties not in desired state.
 
     .PARAMETER IncludeValue
         Indicates that result contains the ActualValue and ExcpectedValue properties.
@@ -459,6 +459,13 @@ function Compare-DscParameterState
                         $param.CurrentValues = $currentArrayValues[$i]
                         $param.DesiredValues = $desiredArrayValues[$i]
 
+                        'IncludeInDesiredState','IncludeValue' | ForEach-Object {
+                            if ($param.ContainsKey($_))
+                            {
+                                $null = $param.Remove($_)
+                            }
+                        }
+
                         if ($InDesiredStateTable.InDesiredState)
                         {
                             $InDesiredStateTable.InDesiredState = Test-DscParameterState @param
@@ -490,6 +497,13 @@ function Compare-DscParameterState
             $param = $PSBoundParameters
             $param.CurrentValues = $currentValue
             $param.DesiredValues = $desiredValue
+
+            'IncludeInDesiredState','IncludeValue' | ForEach-Object {
+                if ($param.ContainsKey($_))
+                {
+                    $null = $param.Remove($_)
+                }
+            }
 
             if ($InDesiredStateTable.InDesiredState)
             {

--- a/source/Public/Test-DscParameterState.ps1
+++ b/source/Public/Test-DscParameterState.ps1
@@ -120,15 +120,7 @@ function Test-DscParameterState
 
         [Parameter()]
         [System.Management.Automation.SwitchParameter]
-        $SortArrayValues,
-
-        [Parameter()]
-        [System.Management.Automation.SwitchParameter]
-        $IncludeInDesiredState,
-
-        [Parameter()]
-        [System.Management.Automation.SwitchParameter]
-        $IncludeValue
+        $SortArrayValues
     )
 
     $returnValue = $true

--- a/source/Public/Test-DscParameterState.ps1
+++ b/source/Public/Test-DscParameterState.ps1
@@ -33,13 +33,6 @@
         If the sorting of array values does not matter, values are sorted internally
         before doing the comparison.
 
-    .PARAMETER IncludeInDesiredState
-        Indicates that result adds the properties in desired state.
-        By default, this command return only the properties in not desired state.
-
-    .PARAMETER IncludeValue
-        Indicates that result contains the ActualValue and ExcpectedValue properties.
-
     .EXAMPLE
         $currentState = Get-TargetResource @PSBoundParameters
 


### PR DESCRIPTION
#### Pull Request (PR) description

Correct typo of my last [PR](https://github.com/dsccommunity/DscResource.Common/pull/56).
Removing IncludeDesiredState and IncludeValue parameters in Test-DscParameterState.
I added those parameters to correct an exception when Compare-DscParameterState call Test-DscParameterState with splatting. 
But this was nonsense. 
Now, Compare-DscParameterState removes IncludeDesiredState and IncludeValue in splatting.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [x] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.common/58)
<!-- Reviewable:end -->
