### PR TITLE
Added cmdlet Get-ComputerName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added cmdlet `Get-ComputerName` which can be used to returns the computer
+  name cross-plattform. The variable `$env:COMPUTERNAME` does not exist
+  cross-platform which hinders development and testing on macOS and Linux.
+  Instead this cmdlet can be used to get the computer name cross-plattform.
+
 ## [0.10.0] - 2020-11-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The properties of psobject are Property,InDesiredState,ExpectedType,ActualType,
   ExpectedValue and ActualValue. The IncludeInDesiredState parameter must be use to
   add ExeptedValue and ActualValue.
-- Added pester test to test the pscredential object with `Compare-DscParameterState`.
+- Added pester test to test the pscredential object with Ä'`Compare-DscParameterState`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The properties of psobject are Property,InDesiredState,ExpectedType,ActualType,
   ExpectedValue and ActualValue. The IncludeInDesiredState parameter must be use to
   add ExeptedValue and ActualValue.
-- Added pester test to test the pscredential object with Ä'`Compare-DscParameterState`.
+- Added pester test to test the pscredential object with `Compare-DscParameterState`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -455,6 +455,35 @@ ConvertTo-HashTable -CimInstance $cimInstance
 This creates a array om CimInstances of the class name MSFT_KeyValuePair
 and passes it to ConvertTo-HashTable which returns a hashtable.
 
+### `Get-ComputerName`
+
+Returns the computer name cross-plattform. The variable `$env:COMPUTERNAME`
+does not exist cross-platform which hinders development and testing on
+macOS and Linux. Instead this cmdlet can be used to get the computer name
+cross-plattform.
+
+#### Syntax
+
+<!-- markdownlint-disable MD013 - Line length -->
+```plaintext
+Get-ComputerName [<CommonParameters>]
+```
+<!-- markdownlint-enable MD013 - Line length -->
+
+#### Outputs
+
+**System.String**
+
+#### Notes
+
+None.
+
+#### Example
+
+```powershell
+$computerName = Get-ComputerName
+```
+
 ### `Get-LocalizedData`
 
 Gets language-specific data into scripts and functions based on the UI culture

--- a/source/Public/Get-ComputerName.ps1
+++ b/source/Public/Get-ComputerName.ps1
@@ -1,0 +1,37 @@
+<#
+    .SYNOPSIS
+        Returns the computer name cross-plattform.
+
+    .DESCRIPTION
+        The variable `$env:COMPUTERNAME` does not exist cross-platform which
+        hinders development and testing on macOS and Linux. Instead this cmdlet
+        can be used to get the computer name cross-plattform.
+
+    .EXAMPLE
+        Get-ComputerName
+
+        This example returns the computer name cross-plattform.
+#>
+function Get-ComputerName
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param ()
+
+    $computerName = $null
+
+    if ($IsLinux -or $IsMacOs)
+    {
+        $computerName = hostname
+    }
+    else
+    {
+        <#
+            We could run 'hostname' on Windows too, but $env:COMPUTERNAME
+            is more widely used.
+        #>
+        $computerName = $env:COMPUTERNAME
+    }
+
+    return $computerName
+}

--- a/tests/Integration/Public/Get-ComputerName.Tests.ps1
+++ b/tests/Integration/Public/Get-ComputerName.Tests.ps1
@@ -1,0 +1,46 @@
+$ProjectPath = "$PSScriptRoot\..\..\.." | Convert-Path
+$ProjectName = ((Get-ChildItem -Path $ProjectPath\*\*.psd1).Where{
+        ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
+    $(try { Test-ModuleManifest -Path $_.FullName -ErrorAction Stop } catch { $false } )
+    }).BaseName
+
+
+Import-Module $ProjectName
+
+InModuleScope $ProjectName {
+    Describe 'Get-ComputerName' {
+        BeforeAll {
+            $mockComputerName = 'MyComputer'
+
+            if ($IsLinux -or $IsMacOs)
+            {
+                function hostname
+                {
+                }
+
+                Mock -CommandName 'hostname' -MockWith {
+                    return $mockComputerName
+                }
+            }
+            else
+            {
+                $previousComputerName = [Environment]::GetEnvironmentVariable('COMPUTERNAME', 'User')
+
+                [Environment]::SetEnvironmentVariable('COMPUTERNAME', $mockComputerName, 'User')
+            }
+        }
+
+        AfterAll {
+            if (-not ($IsLinux -or $IsMacOs))
+            {
+                [Environment]::SetEnvironmentVariable('COMPUTERNAME', $previousComputerName, 'User')
+            }
+        }
+
+        Context 'When getting computer name' {
+            It 'Should return the correct computer name' {
+                Get-ComputerName | Should -Be $mockComputerName
+            }
+        }
+    }
+}

--- a/tests/Unit/Public/Get-ComputerName.Tests.ps1
+++ b/tests/Unit/Public/Get-ComputerName.Tests.ps1
@@ -24,16 +24,7 @@ InModuleScope $ProjectName {
             }
             else
             {
-                $previousComputerName = [Environment]::GetEnvironmentVariable('COMPUTERNAME', 'User')
-
-                [Environment]::SetEnvironmentVariable('COMPUTERNAME', $mockComputerName, 'User')
-            }
-        }
-
-        AfterAll {
-            if (-not ($IsLinux -or $IsMacOs))
-            {
-                [Environment]::SetEnvironmentVariable('COMPUTERNAME', $previousComputerName, 'User')
+                $mockComputerName = $env:COMPUTERNAME
             }
         }
 


### PR DESCRIPTION

#### Pull Request (PR) description
- Added cmdlet `Get-ComputerName` which can be used to returns the computer
  name cross-plattform. The variable `$env:COMPUTERNAME` does not exist
  cross-platform which hinders development and testing on macOS and Linux.
  Instead this cmdlet can be used to get the computer name cross-plattform.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Documentation added/updated in README.md.
- [x] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.common/60)
<!-- Reviewable:end -->
