### PR TITLE
Assert-Module: Reduce verbose output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - DscResource.Common
-  - Renamed default branch to `main` ([issue #62](https://github.com/dsccommunity/DscResource.Common/issues/62)).
+  - Renamed default branch to `main` - fixes [issue #62](https://github.com/dsccommunity/DscResource.Common/issues/62).
 - `Assert-Module`
   - Now it possible to forcibly import a module using `-ImportModule -Force`
   - It no longer outputs verbose messages that is normally generated when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - DscResource.Common
   - Renamed default branch to `main` - fixes [issue #62](https://github.com/dsccommunity/DscResource.Common/issues/62).
+  - Changed to use the new GitHub deploy tasks.
 - `Assert-Module`
   - Now it possible to forcibly import a module using `-ImportModule -Force`
   - It no longer outputs verbose messages that is normally generated when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Renamed default branch to `main` - fixes [issue #62](https://github.com/dsccommunity/DscResource.Common/issues/62).
+- DscResource.Common
+  - Renamed default branch to `main` ([issue #62](https://github.com/dsccommunity/DscResource.Common/issues/62)).
+- `Assert-Module`
+  - Now it possible to forcibly import a module using `-ImportModule -Force`
+  - It no longer outputs verbose messages that is normally generated when
+    using `Get-Module -ListAvailable` if the module that is asserted is
+    already in the session ([issue #66](https://github.com/dsccommunity/DscResource.Common/issues/66)).
 
 ## [0.10.1] - 2020-12-25
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ import the module.
 #### Syntax
 
 ```plaintext
-Assert-Module [-ModuleName] <string> [-ImportModule] [<CommonParameters>]
+Assert-Module [-ModuleName] <string> [-ImportModule] [-Force] [<CommonParameters>]
 ```
 
 #### Outputs
@@ -144,6 +144,14 @@ Assert-Module -ModuleName 'DhcpServer' -ImportModule
 This will assert that the module DhcpServer is available and that it has
 been imported into the session. If the module is not available an exception
 will be thrown.
+
+```powershell
+Assert-Module -ModuleName 'DhcpServer' -ImportModule -Force
+```
+
+This will assert that the module DhcpServer is available and it will be
+forcibly imported into the session (even if it was already in the session).
+If the module is not available an exception will be thrown.
 
 ### `Compare-DscParameterState`
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -14,6 +14,7 @@
     ModuleBuilder               = 'latest'
     ChangelogManagement         = 'latest'
     Sampler                     = 'latest'
+    'Sampler.GitHubTasks'       = 'latest'
     MarkdownLinkCheck           = 'latest'
     'DscResource.AnalyzerRules' = 'latest'
     xDscResourceDesigner        = 'latest'

--- a/build.yaml
+++ b/build.yaml
@@ -73,6 +73,8 @@ Resolve-Dependency:
 ModuleBuildTasks:
   Sampler:
     - '*.build.Sampler.ib.tasks'
+  Sampler.GitHubTasks:
+    - '*.ib.tasks'
 
 TaskHeader: |
   param($Path)

--- a/source/Public/Assert-Module.ps1
+++ b/source/Public/Assert-Module.ps1
@@ -9,12 +9,29 @@
         Specifies the name of the module to assert.
 
     .PARAMETER ImportModule
-        Specfiies to import the module if it is asserted.
+        Specifies to import the module if it is asserted.
+
+    .PARAMETER Force
+        Specifies to forcibly import the module even if it is already in the
+        session. THis parameter is ignored unless parameter `ImportModule` is
+        also used.
 
     .EXAMPLE
         Assert-Module -ModuleName 'DhcpServer'
 
         This asserts that the module DhcpServer is available on the system.
+
+    .EXAMPLE
+        Assert-Module -ModuleName 'DhcpServer' -ImportModule
+
+        This asserts that the module DhcpServer is available on the system and
+        imports it.
+
+    .EXAMPLE
+        Assert-Module -ModuleName 'DhcpServer' -ImportModule -Force
+
+        This asserts that the module DhcpServer is available on the system and
+        forcibly imports it.
 #>
 function Assert-Module
 {
@@ -27,17 +44,37 @@ function Assert-Module
 
         [Parameter()]
         [System.Management.Automation.SwitchParameter]
-        $ImportModule
+        $ImportModule,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Force
     )
 
-    if (-not (Get-Module -Name $ModuleName -ListAvailable))
+    <#
+        If the module is already in the session there is no need to use -ListAvailable.
+        This is a fix for issue #66.
+    #>
+    if (-not (Get-Module -Name $ModuleName))
     {
-        $errorMessage = $script:localizedData.ModuleNotFound -f $ModuleName
-        New-ObjectNotFoundException -Message $errorMessage
+        if (-not (Get-Module -Name $ModuleName -ListAvailable))
+        {
+            $errorMessage = $script:localizedData.ModuleNotFound -f $ModuleName
+            New-ObjectNotFoundException -Message $errorMessage
+        }
     }
 
     if ($ImportModule)
     {
-        Import-Module -Name $ModuleName
+        $importModuleParameters = @{
+            Name = $ModuleName
+        }
+
+        if ($PSBoundParameters.ContainsKey('Force') -and $Force)
+        {
+            $importModuleParameters['Force'] = $true
+        }
+
+        Import-Module @importModuleParameters
     }
 }

--- a/source/Public/Assert-Module.ps1
+++ b/source/Public/Assert-Module.ps1
@@ -63,7 +63,8 @@ function Assert-Module
             New-ObjectNotFoundException -Message $errorMessage
         }
 
-        if ($ImportModule)
+        # Only import it here if $Force is not set, otherwise it will be imported below.
+        if ($ImportModule -and -not $Force)
         {
             Import-Module -Name $ModuleName
         }

--- a/source/Public/Assert-Module.ps1
+++ b/source/Public/Assert-Module.ps1
@@ -13,7 +13,7 @@
 
     .PARAMETER Force
         Specifies to forcibly import the module even if it is already in the
-        session. THis parameter is ignored unless parameter `ImportModule` is
+        session. This parameter is ignored unless parameter `ImportModule` is
         also used.
 
     .EXAMPLE

--- a/source/Public/Assert-Module.ps1
+++ b/source/Public/Assert-Module.ps1
@@ -62,19 +62,16 @@ function Assert-Module
             $errorMessage = $script:localizedData.ModuleNotFound -f $ModuleName
             New-ObjectNotFoundException -Message $errorMessage
         }
+
+        if ($ImportModule)
+        {
+            Import-Module -Name $ModuleName
+        }
     }
 
-    if ($ImportModule)
+    # Always import the module even if already in session.
+    if ($ImportModule -and $Force)
     {
-        $importModuleParameters = @{
-            Name = $ModuleName
-        }
-
-        if ($PSBoundParameters.ContainsKey('Force') -and $Force)
-        {
-            $importModuleParameters['Force'] = $true
-        }
-
-        Import-Module @importModuleParameters
+        Import-Module -Name $ModuleName -Force
     }
 }

--- a/tests/Unit/Public/Assert-Module.Tests.ps1
+++ b/tests/Unit/Public/Assert-Module.Tests.ps1
@@ -24,45 +24,76 @@ InModuleScope $ProjectName {
             }
         }
 
-        Context 'When module is available' {
-            BeforeAll {
-                Mock -CommandName Import-Module
-                Mock -CommandName Get-Module -MockWith {
-                    return @{
-                        Name = $testModuleName
+        Context 'When module is installed' {
+            Context 'When module is already present in session' {
+                BeforeAll {
+                    Mock -CommandName Import-Module
+                    Mock -CommandName Get-Module -MockWith {
+                        return @{
+                            Name = $testModuleName
+                        }
+                    }
+                }
+
+                Context 'When asserting that module is available' {
+                    It 'Should not throw an error' {
+                        { Assert-Module -ModuleName $testModuleName } | Should -Not -Throw
+                    }
+
+                    It 'Should call the expected mocks' {
+                        Assert-MockCalled -CommandName Import-Module -Exactly -Times 0
+                    }
+                }
+
+                Context 'When using ImportModule but module is already imported' {
+                    It 'Should not throw an error' {
+                        { Assert-Module -ModuleName $testModuleName -ImportModule } | Should -Not -Throw
+                    }
+
+                    It 'Should call the expected mocks' {
+                        Assert-MockCalled -CommandName Import-Module -Exactly -Times 0
+                    }
+                }
+
+                Context 'When module should be forcibly imported' {
+                    It 'Should not throw an error' {
+                        { Assert-Module -ModuleName $testModuleName -ImportModule -Force } | Should -Not -Throw
+                    }
+
+                    It 'Should call the expected mocks' {
+                        Assert-MockCalled -CommandName Import-Module -ParameterFilter {
+                            $Force -eq $true
+                        } -Exactly -Times 1
                     }
                 }
             }
 
-            Context 'When module should not be imported' {
-                It 'Should not throw an error' {
-                    { Assert-Module -ModuleName $testModuleName } | Should -Not -Throw
+            Context 'When module is not present in the session' {
+                BeforeAll {
+                    Mock -CommandName Import-Module
+                    Mock -CommandName Get-Module -MockWith {
+                        return $null
+                    } -ParameterFilter {
+                        $ListAvailable -eq $false
+                    }
+
+                    Mock -CommandName Get-Module -MockWith {
+                        return @{
+                            Name = $testModuleName
+                        }
+                    } -ParameterFilter {
+                        $ListAvailable -eq $true
+                    }
                 }
 
-                It 'Should call the expected mocks' {
-                    Assert-MockCalled -CommandName Import-Module -Exactly -Times 0
-                }
-            }
+                Context 'When module should be imported' {
+                    It 'Should not throw an error' {
+                        { Assert-Module -ModuleName $testModuleName -ImportModule } | Should -Not -Throw
+                    }
 
-            Context 'When module should be imported' {
-                It 'Should not throw an error' {
-                    { Assert-Module -ModuleName $testModuleName -ImportModule } | Should -Not -Throw
-                }
-
-                It 'Should call the expected mocks' {
-                    Assert-MockCalled -CommandName Import-Module -Exactly -Times 1
-                }
-            }
-
-            Context 'When module should be forcibly imported' {
-                It 'Should not throw an error' {
-                    { Assert-Module -ModuleName $testModuleName -ImportModule -Force } | Should -Not -Throw
-                }
-
-                It 'Should call the expected mocks' {
-                    Assert-MockCalled -CommandName Import-Module -ParameterFilter {
-                        $Force -eq $true
-                    } -Exactly -Times 1
+                    It 'Should call the expected mocks' {
+                        Assert-MockCalled -CommandName Import-Module -Exactly -Times 1
+                    }
                 }
             }
         }

--- a/tests/Unit/Public/Assert-Module.Tests.ps1
+++ b/tests/Unit/Public/Assert-Module.Tests.ps1
@@ -38,7 +38,7 @@ InModuleScope $ProjectName {
                 It 'Should not throw an error' {
                     { Assert-Module -ModuleName $testModuleName } | Should -Not -Throw
                 }
-                
+
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Import-Module -Exactly -Times 0
                 }
@@ -48,9 +48,21 @@ InModuleScope $ProjectName {
                 It 'Should not throw an error' {
                     { Assert-Module -ModuleName $testModuleName -ImportModule } | Should -Not -Throw
                 }
-                
+
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Import-Module -Exactly -Times 1
+                }
+            }
+
+            Context 'When module should be forcibly imported' {
+                It 'Should not throw an error' {
+                    { Assert-Module -ModuleName $testModuleName -ImportModule -Force } | Should -Not -Throw
+                }
+
+                It 'Should call the expected mocks' {
+                    Assert-MockCalled -CommandName Import-Module -ParameterFilter {
+                        $Force -eq $true
+                    } -Exactly -Times 1
                 }
             }
         }


### PR DESCRIPTION

#### Pull Request (PR) description
- `Assert-Module`
  - Now it possible to forcibly import a module using `-ImportModule -Force`
  - It no longer outputs verbose messages that is normally generated when
    using `Get-Module -ListAvailable` if the module that is asserted is
    already in the session (issue #66).

#### This Pull Request (PR) fixes the following issues

- Fixes #66

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Documentation added/updated in README.md.
- [x] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.common/67)
<!-- Reviewable:end -->
