### PR TITLE
Compare-DscParameterState: Fix verbose message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Renamed default branch to `main` - fixes [issue #62](https://github.com/dsccommunity/DscResource.Common/issues/62).
+- `Compare-DscParameterState`
+  - Fix verbose message to only show when using parameter `IncludeInDesiredState`.
+    Also made the verbose message more intuitive when the value being compared
+    was a `[System.Boolean]`.
 
 ## [0.10.1] - 2020-12-25
 

--- a/source/Public/Compare-DscParameterState.ps1
+++ b/source/Public/Compare-DscParameterState.ps1
@@ -577,9 +577,21 @@ function Compare-DscParameterState
     }
 
     #change verbose message
-    $returnValue.foreach({
-        Write-Verbose -Message ($script:localizedData.CompareDscParameterResultMessage -f $_.Property,$_.InDesiredState)
-    })
+    if ($IncludeInDesiredState.IsPresent)
+    {
+        $returnValue.ForEach({
+            if ($_.InDesiredState)
+            {
+                $localizedString = $script:localizedData.PropertyInDesiredStateMessage
+            }
+            else
+            {
+                $localizedString = $script:localizedData.PropertyNotInDesiredStateMessage
+            }
+
+            Write-Verbose -Message ($localizedString -f $_.Property)
+        })
+    }
     <#
         If Compare-DscParameterState is used in precedent step, don't need to convert it
         We use .foreach() method as we are sure that $returnValue is an array.

--- a/source/en-US/DscResource.Common.strings.psd1
+++ b/source/en-US/DscResource.Common.strings.psd1
@@ -19,7 +19,7 @@ ConvertFrom-StringData @'
     NoMatchElementTypeMismatchMessage = NOTMATCH: Type mismatch for property '{0}' Current state type of element [{1}] is '{2}' and desired type is '{3}'. (DRC0023)
     NoMatchElementValueMismatchMessage = NOTMATCH: Value [{0}] (type '{1}') for property '{2}' does match. Current state is '{3}' and desired state is '{4}'. (DRC0024)
     MatchElementValueMessage = MATCH: Value [{0}] (type '{1}') for property '{2}' does match. Current state is '{3}' and desired state is '{4}'. (DRC0025)
-    CompareDscParameterResultMessage = Compare-DscParameterState result : Property '{0}' is in desired state '{1}' . (DRC0026)
+    PropertyInDesiredStateMessage = Property '{0}' is in desired state. (DRC0026)
     StartingReverseCheck = Starting with a reverse check. (DRC0027)
     TestDscParameterCompareMessage = Comparing values in property '{0}'. (DRC0028)
     TooManyCimInstances = More than one CIM instance was returned from the current state. (DRC0029)
@@ -34,4 +34,5 @@ ConvertFrom-StringData @'
     EvaluatePropertyState = Evaluating the state of the property '{0}'. (DRC0038)
     PropertyInDesiredState = The parameter '{0}' is in desired state. (DRC0039)
     PropertyNotInDesiredState = The parameter '{0}' is not in desired state. (DRC0040)
+    PropertyNotInDesiredStateMessage = Property '{0}' is not in desired state. (DRC0041)
 '@


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure the PR title is short but a descriptive
    summary of the PR,
    e.g "String arrays where not allowed if it had un unsupported value map".

    You may remove this comment block, and the other comment blocks,
    but please keep the headers and the task list.
-->
#### Pull Request (PR) description
- `Compare-DscParameterState`
  - Fix verbose message to only show when using parameter `IncludeInDesiredState`.
    Also made the verbose message more intuitive when the value being compared
    was a `[System.Boolean]`.
#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated for all new/changed functions.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.common/68)
<!-- Reviewable:end -->
