### PR TITLE
adding some fixes to Get-LocalizedData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - DscResource.Common
-  - updating the Get-LocalizedData to completely bypass Import-LocalizedData when in invariant culture.
+  - updating the Get-LocalizedData to bypass Import-LocalizedData when in Globalization-Invariant mode.
     The command throws when running on an Invariant culture on Linux in the latest PS versions.
 
 ## [0.11.0] - 2022-08-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- DscResource.Common
+  - updating the Get-LocalizedData to completely bypass Import-LocalizedData when in invariant culture.
+    The command throws when running on an Invariant culture on Linux in the latest PS versions.
+
 ## [0.11.0] - 2022-08-01
 
 ### Changed

--- a/source/Public/Get-LocalizedData.ps1
+++ b/source/Public/Get-LocalizedData.ps1
@@ -1,3 +1,4 @@
+
 <#
     .SYNOPSIS
         Gets language-specific data into scripts and functions based on the UI culture
@@ -312,8 +313,19 @@ function Get-LocalizedData
                 $PSBoundParameters['OutBuffer'] = 1
             }
 
-            $wrappedCmd = $ExecutionContext.InvokeCommand.GetCommand('Microsoft.PowerShell.Utility\Import-LocalizedData', [System.Management.Automation.CommandTypes]::Cmdlet)
-            $scriptCmd = { & $wrappedCmd @PSBoundParameters }
+            if ($currentCulture.LCID -eq 127)
+            {
+                # Culture is invariant, working around issue with Import-LocalizedData when pwsh configured as invariant
+                $wrappedCmd = $ExecutionContext.InvokeCommand.GetCommand('Get-LocalizedDataForInvariantCulture', [System.Management.Automation.CommandTypes]::Function)
+                $scriptCmd = { & $wrappedCmd -DefaultUICulture $DefaultUICulture - }
+            }
+            else
+            {
+                <# Action when all if and elseif conditions are false #>
+                $wrappedCmd = $ExecutionContext.InvokeCommand.GetCommand('Microsoft.PowerShell.Utility\Import-LocalizedData', [System.Management.Automation.CommandTypes]::Cmdlet)
+                $scriptCmd = { & $wrappedCmd @PSBoundParameters }
+            }
+
 
             $steppablePipeline = $scriptCmd.GetSteppablePipeline($myInvocation.CommandOrigin)
             $steppablePipeline.Begin($PSCmdlet)

--- a/source/Public/Get-LocalizedData.ps1
+++ b/source/Public/Get-LocalizedData.ps1
@@ -176,7 +176,11 @@ function Get-LocalizedData
             Because Proxy Command changes the Invocation origin, we need to be explicit
             when handing the pipeline back to original command.
         #>
-        if (!$PSBoundParameters.ContainsKey('FileName'))
+        if ($PSBoundParameters.ContainsKey('FileName'))
+        {
+            Write-Debug -Message ('Looking for provided file with base name: ''{0}''.' -f $FileName)
+        }
+        else
         {
             if ($myInvocation.ScriptName)
             {
@@ -190,6 +194,7 @@ function Get-LocalizedData
             $FileName = $file.BaseName
 
             $PSBoundParameters.Add('FileName', $file.Name)
+            Write-Debug -Message ('Looking for resolved file with base name: ''{0}''.' -f $FileName)
         }
 
         if ($PSBoundParameters.ContainsKey('BaseDirectory'))
@@ -199,75 +204,81 @@ function Get-LocalizedData
         else
         {
             $callingScriptRoot = $MyInvocation.PSScriptRoot
-
             $PSBoundParameters.Add('BaseDirectory', $callingScriptRoot)
         }
 
-        if ($PSBoundParameters.ContainsKey('DefaultUICulture') -and !$PSBoundParameters.ContainsKey('UICulture'))
+        # If we're not looking for a specific UICulture, but looking for current culture, one of its parent, or the default.
+        if (-not $PSBoundParameters.ContainsKey('UICulture') -and $PSBoundParameters.ContainsKey('DefaultUICulture'))
         {
             <#
                 We don't want the resolution to eventually return the ModuleManifest
                 so we run the same GetFilePath() logic than here:
                 https://github.com/PowerShell/PowerShell/blob/master/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs#L302-L333
-                and if we see it will return the wrong thing, set the UICulture to DefaultUI culture, and return the logic to Import-LocalizedData
-            #>
-            $currentCulture = Get-UICulture
+                and if we see it will return the wrong thing, set the UICulture to DefaultUI culture, and return the logic to Import-LocalizedData.
 
+                If the LCID is 127 (invariant) then use default UI culture anyway.
+                If we can't create the CultureInfo object, it's probably because the Globalization-invariant mode is enabled for the DotNet runtime (breaking change in .Net)
+                See more information in issue https://github.com/dsccommunity/DscResource.Common/issues/11.
+                https://docs.microsoft.com/en-us/dotnet/core/compatibility/globalization/6.0/culture-creation-invariant-mode
+            #>
+
+            $currentCulture = Get-UICulture
             $evaluateDefaultCulture = $true
 
-            <#
-                If the LCID is 127 then use default UI culture instead.
-
-                See more information in issue https://github.com/dsccommunity/DscResource.Common/issues/11.
-            #>
             if ($currentCulture.LCID -eq 127)
             {
-                $currentCulture = New-Object -TypeName 'System.Globalization.CultureInfo' -ArgumentList @($DefaultUICulture)
-                $PSBoundParameters['UICulture'] = $DefaultUICulture
+                try
+                {
+                    # Current culture is invariant, let's directly evaluate the DefaultUICulture
+                    $currentCulture = New-Object -TypeName 'System.Globalization.CultureInfo' -ArgumentList @($DefaultUICulture)
+                    # No need to evaluate the DefaultUICulture later, as we'll start with this (in the while loop below)
+                    $evaluateDefaultCulture = $false
+                }
+                catch
+                {
+                    Write-Debug -Message 'The Globalization-Invariant mode is enabled, only the Invariant Culture is allowed.'
+                    # The code will now skip to the InvokeCommand part and execute the Get-LocalizedDataForInvariantCulture
+                }
 
-                $evaluateDefaultCulture = $false
+                $PSBoundParameters['UICulture'] = $DefaultUICulture
             }
 
-            $languageFile = $null
-
-            $localizedFileNames = @(
-                $FileName + '.psd1'
-                $FileName + '.strings.psd1'
+            [string] $languageFile = ''
+            [string[]] $localizedFileNamesToTry = @(
+                ('{0}.psd1' -f $FileName)
+                ('{0}.strings.psd1' -f $FileName)
             )
 
-            while ($null -ne $currentCulture -and $currentCulture.Name -and -not $languageFile)
+            while (-not [string]::IsNullOrEmpty($currentCulture.Name) -and [String]::IsNullOrEmpty($languageFile))
             {
-                foreach ($fullFileName in $localizedFileNames)
+                Write-Debug -Message ('Looking for Localized data file using the current culture ''{0}''.' -f $currentCulture.Name)
+                foreach ($localizedFileName in $localizedFileNamesToTry)
                 {
-                    $filePath = [System.IO.Path]::Combine($callingScriptRoot, $CurrentCulture.Name, $fullFileName)
-
+                    $filePath = [System.IO.Path]::Combine($callingScriptRoot, $CurrentCulture.Name, $localizedFileName)
                     if (Test-Path -Path $filePath)
                     {
-                        Write-Debug -Message "Found $filePath"
-
+                        Write-Debug -Message "Found '$filePath'."
                         $languageFile = $filePath
-
                         # Set the filename to the file we found.
-                        $PSBoundParameters['FileName'] = $fullFileName
-
-                        # Exit loop if we find the first filename.
+                        $PSBoundParameters['FileName'] = $localizedFileName
+                        # Exit loop if as we found the first filename.
                         break
                     }
                     else
                     {
-                        Write-Debug -Message "File $filePath not found"
+                        Write-Debug -Message "File '$filePath' not found."
                     }
                 }
 
-                if (-not $languageFile)
+                if ([String]::IsNullOrEmpty($languageFile))
                 {
                     <#
-                        Evaluate the parent culture if there is one.
+                        Evaluate the parent culture if there is a valid one (not Invariant).
 
                         If the parent culture is LCID 127 then move to the default culture.
                         See more information in issue https://github.com/dsccommunity/DscResource.Common/issues/11.
                     #>
-                    if ($currentCulture.Parent -and $currentCulture.Parent.LCID -ne 127)
+                    if ($currentCulture.Parent -and [string]$currentCulture.Parent.Name)
                     {
                         $currentCulture = $currentCulture.Parent
                     }
@@ -282,7 +293,18 @@ function Get-LocalizedData
                                 system UI culture. Evaluating the default UI culture (which
                                 defaults to 'en-US' if not specifically set).
                             #>
-                            $currentCulture = New-Object -TypeName 'System.Globalization.CultureInfo' -ArgumentList @($DefaultUICulture)
+                            try
+                            {
+                                $currentCulture = New-Object -TypeName 'System.Globalization.CultureInfo' -ArgumentList @($DefaultUICulture)
+                            }
+                            catch
+                            {
+                                Write-Debug -Message ('Unable to create the Default UI Culture [CultureInfo] object, most likely due to invariant mode being enabled.')
+                                $currentCulture = Get-UICulture
+                                # We already tried everything we could, exit the while loop and hand over to Import-LocalizedData or Get-LocalizedDataForInvariantCultureMode
+                                break
+                            }
+
                             $PSBoundParameters['UICulture'] = $DefaultUICulture
                         }
                         else
@@ -317,7 +339,14 @@ function Get-LocalizedData
             {
                 # Culture is invariant, working around issue with Import-LocalizedData when pwsh configured as invariant
                 $wrappedCmd = $ExecutionContext.InvokeCommand.GetCommand('Get-LocalizedDataForInvariantCulture', [System.Management.Automation.CommandTypes]::Function)
-                $scriptCmd = { & $wrappedCmd -DefaultUICulture $DefaultUICulture - }
+                $PSBoundParameters.Keys.ForEach({
+                    if ($_ -notin $wrappedCmd.Parameters.Keys)
+                    {
+                        $PSBoundParameters.Remove($_)
+                    }
+                })
+
+                $scriptCmd = { & $wrappedCmd @PSBoundParameters }
             }
             else
             {
@@ -325,7 +354,6 @@ function Get-LocalizedData
                 $wrappedCmd = $ExecutionContext.InvokeCommand.GetCommand('Microsoft.PowerShell.Utility\Import-LocalizedData', [System.Management.Automation.CommandTypes]::Cmdlet)
                 $scriptCmd = { & $wrappedCmd @PSBoundParameters }
             }
-
 
             $steppablePipeline = $scriptCmd.GetSteppablePipeline($myInvocation.CommandOrigin)
             $steppablePipeline.Begin($PSCmdlet)

--- a/source/Public/Get-LocalizedDataForInvariantCulture.ps1
+++ b/source/Public/Get-LocalizedDataForInvariantCulture.ps1
@@ -7,9 +7,10 @@
         of invariant culture (as in the Guest Config agent).
 
     .DESCRIPTION
-        The Get-LocalizedDataForInvariantCulture grabs the data from a localized string data psd1,
-        without calling Import-LocalizedData which errors when called in a session set to invariant
-        culture in the pwsh config.
+        The Get-LocalizedDataForInvariantCulture grabs the data from a localized string data psd1 file,
+        without calling Import-LocalizedData which errors when called in a powershell session with the
+        Globalization-Invariant mode enabled
+        (https://docs.microsoft.com/en-us/dotnet/core/compatibility/globalization/6.0/culture-creation-invariant-mode).
 
         Instead, this function reads and executes the content of a psd1 file in a
         constrained language mode that only allows basic ConvertFrom-stringData.
@@ -21,17 +22,18 @@
         directory.
 
     .PARAMETER FileName
-        Specifies the name of the data file (.psd1) to be imported. Enter a file name.
+        Specifies the base name of the data file (.psd1) to be imported. Enter a file name.
         You can specify a file name that does not include its .psd1 file name extension,
         or you can specify the file name including the .psd1 file name extension.
 
-        The FileName parameter is required when Import-LocalizedData is not used in a
+        The FileName parameter is required when Get-LocalizedDataForInvariantCulture is not used in a
         script. Otherwise, the parameter is optional and the default value is the base
-        name of the script. You can use this parameter to direct Import-LocalizedData
-        to search for a different .psd1 file.
+        name of the calling script. You can use this parameter to directly search for a
+        specific .psd1 file.
 
         For example, if the FileName is omitted and the script name is FindFiles.ps1,
-        Import-LocalizedData searches for the FindFiles.psd1 data file.
+        Get-LocalizedDataForInvariantCulture searches for the FindFiles.psd1 or
+        FindFiles.strings.psd1 data file.
 
     .PARAMETER SupportedCommand
         Specifies cmdlets and functions that generate only data.
@@ -47,6 +49,11 @@
         your current culture is 'en-GB', you can default back to 'en-US'.
 
     .NOTES
+        The Get-LocalizedDataForInvariantCulture should only be used when we want to avoid
+        using Import-LocalizedData, such as when doing so will fail because the powershell session
+        is in Globalization-Invariant mode:
+        https://docs.microsoft.com/en-us/dotnet/core/compatibility/globalization/6.0/culture-creation-invariant-mode
+
         Before using Get-LocalizedDataForInvariantCulture, localize your user messages to the desired
         default locale (UI culture, usually en-US) in a hash table of key/value pairs, and save the
         hash table in a file with the same name as the script or module with a .psd1 file name extension.
@@ -61,37 +68,22 @@
         Import-LocalizedData performs a structured search for the localized user
         messages for a script.
 
-        Import-LocalizedData begins the search in the directory where the script file
-        is located (or the value of the BaseDirectory parameter). It then searches within
-        the base directory for a subdirectory with the same name as the value of the
-        $PsUICulture variable (or the value of the UICulture parameter), such as de-DE or
-        ar-SA. Then, it searches in that subdirectory for a .psd1 file with the same name
-        as the script (or the value of the FileName parameter).
-
-        If Import-LocalizedData cannot find a subdirectory with the name of the UI culture,
-        or the subdirectory does not contain a .psd1 file for the script, it searches for
-        a .psd1 file for the script in a subdirectory with the name of the language code,
-        such as de or ar. If it cannot find the subdirectory or .psd1 file, the command
-        fails, the data is displayed in the default language in the script, and an error
-        message is displayed explaining that the data could not be imported. To suppress
-        the message and fail gracefully, use the ErrorAction common parameter with a value
-        of SilentlyContinue.
-
-        If Import-LocalizedData finds the subdirectory and the .psd1 file, it imports the
-        hash table of user messages into the value of the BindingVariable parameter in the
-        command. Then, when you display a message from the hash table in the variable, the
-        localized message is displayed.
-
-        For more information, see about_Script_Internationalization.
+        Get-LocalizedDataForInvariantCulture only search in the BaseDirectory specified.
+        It then searches within the base directory for a subdirectory with the same name
+        as the value of the $DefaultUICulture variable (specified or default to en-US),
+        such as de-DE or ar-SA.
+        Then, it searches in that subdirectory for a .psd1 file with the same name
+        as provided FileName such as FileName.psd1 or FileName.strings.psd1.
 
     .EXAMPLE
-        $script:localizedData = Get-LocalizedDataForInvariantCulture -DefaultUICulture 'en-US'
+        Get-LocalizedDataForInvariantCulture -BaseDirectory .\source\ -FileName DscResource.Common -DefaultUICulture en-US
 
-        This is an example that can be used in DSC resources to import the
-        localized strings.
+        This is an example, usually it is only used by Get-LocalizedData in DSC resources to import the
+        localized strings when the Culture is Invariant (id 127).
 #>
 function Get-LocalizedDataForInvariantCulture
 {
+    [CmdletBinding()]
     param
     (
         [Parameter(Mandatory = $true)]

--- a/source/Public/Get-LocalizedDataForInvariantCulture.ps1
+++ b/source/Public/Get-LocalizedDataForInvariantCulture.ps1
@@ -1,0 +1,203 @@
+
+<#
+    .SYNOPSIS
+        Gets language-specific data when the culture is invariant.
+        This directly gets the data from the DefaultUICulture, but without calling
+        "Import-LocalizedData" which throws when the pwsh session is configured to be
+        of invariant culture (as in the Guest Config agent).
+
+    .DESCRIPTION
+        The Get-LocalizedDataForInvariantCulture grabs the data from a localized string data psd1,
+        without calling Import-LocalizedData which errors when called in a session set to invariant
+        culture in the pwsh config.
+
+        Instead, this function reads and executes the content of a psd1 file in a
+        constrained language mode that only allows basic ConvertFrom-stringData.
+
+    .PARAMETER BaseDirectory
+        Specifies the base directory where the .psd1 files are located. The default is
+        the directory where the script is located. Import-LocalizedData searches for
+        the .psd1 file for the script in a language-specific subdirectory of the base
+        directory.
+
+    .PARAMETER FileName
+        Specifies the name of the data file (.psd1) to be imported. Enter a file name.
+        You can specify a file name that does not include its .psd1 file name extension,
+        or you can specify the file name including the .psd1 file name extension.
+
+        The FileName parameter is required when Import-LocalizedData is not used in a
+        script. Otherwise, the parameter is optional and the default value is the base
+        name of the script. You can use this parameter to direct Import-LocalizedData
+        to search for a different .psd1 file.
+
+        For example, if the FileName is omitted and the script name is FindFiles.ps1,
+        Import-LocalizedData searches for the FindFiles.psd1 data file.
+
+    .PARAMETER SupportedCommand
+        Specifies cmdlets and functions that generate only data.
+
+        Use this parameter to include cmdlets and functions that you have written or
+        tested. For more information, see about_Script_Internationalization.
+
+    .PARAMETER DefaultUICulture
+        Specifies which UICulture to default to if current UI culture or its parents
+        culture don't have matching data file.
+
+        For example, if you have a data file in 'en-US' but not in 'en' or 'en-GB' and
+        your current culture is 'en-GB', you can default back to 'en-US'.
+
+    .NOTES
+        Before using Get-LocalizedDataForInvariantCulture, localize your user messages to the desired
+        default locale (UI culture, usually en-US) in a hash table of key/value pairs, and save the
+        hash table in a file with the same name as the script or module with a .psd1 file name extension.
+        Create a directory under the module base or script's parent directory for each supported UI culture,
+        and then save the .psd1 file for each UI culture in the directory with the UI culture name.
+
+        For example, localize your user messages for the de-DE locale and format them in
+        a hash table. Save the hash table in a <ScriptName>.psd1 file. Then create a de-DE
+        subdirectory under the script directory, and save the de-DE <ScriptName>.psd1
+        file in the de-DE subdirectory. Repeat this method for each locale that you support.
+
+        Import-LocalizedData performs a structured search for the localized user
+        messages for a script.
+
+        Import-LocalizedData begins the search in the directory where the script file
+        is located (or the value of the BaseDirectory parameter). It then searches within
+        the base directory for a subdirectory with the same name as the value of the
+        $PsUICulture variable (or the value of the UICulture parameter), such as de-DE or
+        ar-SA. Then, it searches in that subdirectory for a .psd1 file with the same name
+        as the script (or the value of the FileName parameter).
+
+        If Import-LocalizedData cannot find a subdirectory with the name of the UI culture,
+        or the subdirectory does not contain a .psd1 file for the script, it searches for
+        a .psd1 file for the script in a subdirectory with the name of the language code,
+        such as de or ar. If it cannot find the subdirectory or .psd1 file, the command
+        fails, the data is displayed in the default language in the script, and an error
+        message is displayed explaining that the data could not be imported. To suppress
+        the message and fail gracefully, use the ErrorAction common parameter with a value
+        of SilentlyContinue.
+
+        If Import-LocalizedData finds the subdirectory and the .psd1 file, it imports the
+        hash table of user messages into the value of the BindingVariable parameter in the
+        command. Then, when you display a message from the hash table in the variable, the
+        localized message is displayed.
+
+        For more information, see about_Script_Internationalization.
+
+    .EXAMPLE
+        $script:localizedData = Get-LocalizedDataForInvariantCulture -DefaultUICulture 'en-US'
+
+        This is an example that can be used in DSC resources to import the
+        localized strings.
+#>
+function Get-LocalizedDataForInvariantCulture
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $BaseDirectory,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $FileName,
+
+        [Parameter()]
+        [System.String[]]
+        $SupportedCommand,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DefaultUICulture = 'en-US'
+    )
+
+    begin
+    {
+        $constrainedState = [System.Management.Automation.Runspaces.InitialSessionState]::Create()
+
+        if (!$IsCoreCLR)
+        {
+            $constrainedState.ApartmentState = [System.Threading.ApartmentState]::STA
+        }
+
+        $constrainedState.LanguageMode = [System.Management.Automation.PSLanguageMode]::ConstrainedLanguage
+        $constrainedState.DisableFormatUpdates = $true
+
+        $sspe = New-Object System.Management.Automation.Runspaces.SessionStateProviderEntry 'Environment',([Microsoft.PowerShell.Commands.EnvironmentProvider]),$null
+        $constrainedState.Providers.Add($sspe)
+
+        $sspe = New-Object System.Management.Automation.Runspaces.SessionStateProviderEntry 'FileSystem',([Microsoft.PowerShell.Commands.FileSystemProvider]),$null
+        $constrainedState.Providers.Add($sspe)
+
+        $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-Content',([Microsoft.PowerShell.Commands.GetContentCommand]),$null
+        $constrainedState.Commands.Add($ssce)
+
+        $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-Date',([Microsoft.PowerShell.Commands.GetDateCommand]),$null
+        $constrainedState.Commands.Add($ssce)
+
+        $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-ChildItem',([Microsoft.PowerShell.Commands.GetChildItemCommand]),$null
+        $constrainedState.Commands.Add($ssce)
+
+        $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-Item',([Microsoft.PowerShell.Commands.GetItemCommand]),$null
+        $constrainedState.Commands.Add($ssce)
+
+        $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Test-Path',([Microsoft.PowerShell.Commands.TestPathCommand]),$null
+        $constrainedState.Commands.Add($ssce)
+
+        $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Out-String',([Microsoft.PowerShell.Commands.OutStringCommand]),$null
+        $constrainedState.Commands.Add($ssce)
+
+        $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'ConvertFrom-StringData',([Microsoft.PowerShell.Commands.ConvertFromStringDataCommand]),$null
+        $constrainedState.Commands.Add($ssce)
+
+        # $scopedItemOptions = [System.Management.Automation.ScopedItemOptions]::AllScope
+
+        # Create new runspace with the above defined entries. Then open and set its working dir to $destinationAbsolutePath
+        # so all condition attribute expressions can use a relative path to refer to file paths e.g.
+        # condition="Test-Path src\${PLASTER_PARAM_ModuleName}.psm1"
+        $constrainedRunspace = [System.Management.Automation.Runspaces.RunspaceFactory]::CreateRunspace($constrainedState)
+        $constrainedRunspace.Open()
+        $destinationAbsolutePath = (Get-Item -Path $BaseDirectory -ErrorAction Stop).FullName
+        $null = $constrainedRunspace.SessionStateProxy.Path.SetLocation($destinationAbsolutePath)
+    }
+
+    process
+    {
+        try
+        {
+            $powershell = [PowerShell]::Create()
+            $powershell.Runspace = $constrainedRunspace
+            $localizedFolder = Join-Path -Path $BaseDirectory -ChildPath $DefaultUICulture.ToString()
+            $expression = Get-Content -Raw -Path (Join-Path -Path $localizedFolder -ChildPath $FileName)
+            try
+            {
+                $null = $powershell.AddScript($expression)
+                $powershell.Invoke()
+            }
+            catch
+            {
+                throw $_
+            }
+
+            # Check for non-terminating errors.
+            if ($powershell.Streams.Error.Count -gt 0)
+            {
+                $powershell.Streams.Error.ForEach({
+                    Write-Error $_
+                })
+            }
+        }
+        finally
+        {
+            if ($powershell)
+            {
+                $powershell.Dispose()
+            }
+        }
+    }
+
+    end
+    {
+        $constrainedRunspace.Dispose()
+    }
+}

--- a/source/Public/Get-LocalizedDataForInvariantCulture.ps1
+++ b/source/Public/Get-LocalizedDataForInvariantCulture.ps1
@@ -110,10 +110,10 @@ function Get-LocalizedDataForInvariantCulture
 
     begin
     {
-        if ($FileName -match '\.psm1$|\.ps1$')
+        if ($FileName -match '\.psm1$|\.ps1$|\.psd1$')
         {
             Write-Debug -Message 'Found an extension to the file name to search. Stripping...'
-            $FileName = $FileName -replace '\.psm1$|\.ps1$'
+            $FileName = $FileName -replace '\.psm1$|\.ps1$|\.psd1$'
         }
 
         [string] $languageFile = ''

--- a/tests/Unit/Public/Get-LocalizedDataForInvariantCulture.Tests.ps1
+++ b/tests/Unit/Public/Get-LocalizedDataForInvariantCulture.Tests.ps1
@@ -1,0 +1,35 @@
+BeforeAll {
+    $script:moduleName = 'DscResource.Common'
+
+    # If the module is not found, run the build task 'noop'.
+    if (-not (Get-Module -Name $script:moduleName -ListAvailable))
+    {
+        # Redirect all streams to $null, except the error stream (stream 2)
+        & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+    }
+
+    # Re-import the module using force to get any code changes between runs.
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    Remove-Module -Name $script:moduleName
+}
+
+Describe 'DscResource.Common\Get-LocalizedDataForInvariantCulture' {
+    BeforeAll {
+        $verbose = $false
+    }
+
+    Context 'Testing the thingy' {
+        # $data = Get-LocalizedDataForInvariantCulture -BaseDirectory
+    }
+}


### PR DESCRIPTION
This fixes the issue of loading the module when the Globalization-mode is invariant, and creating non-invariant CultureInfo forbidden.
This is to fix the dotnet change, mostly affecting GC on Linux.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.common/80)
<!-- Reviewable:end -->
