### PR TITLE
`Assert-ElevatedUser`: Minor change to localization key name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `Assert-ElevatedUser`
+  - Renamed the localized string key name and prepared the localized string
+    file to be able to distinguish which key belong to which command.
+
 ## [0.12.0] - 2022-12-10
 
 ### Added

--- a/source/Public/Assert-ElevatedUser.ps1
+++ b/source/Public/Assert-ElevatedUser.ps1
@@ -35,7 +35,7 @@ function Assert-ElevatedUser
     {
         $PSCmdlet.ThrowTerminatingError(
             [System.Management.Automation.ErrorRecord]::new(
-                $script:localizedData.IsElevated_UserNotElevated,
+                $script:localizedData.ElevatedUser_UserNotElevated,
                 'UserNotElevated',
                 [System.Management.Automation.ErrorCategory]::InvalidOperation,
                 'Command parameters'

--- a/source/en-US/DscResource.Common.strings.psd1
+++ b/source/en-US/DscResource.Common.strings.psd1
@@ -36,5 +36,7 @@ ConvertFrom-StringData @'
     PropertyNotInDesiredState = The parameter '{0}' is not in desired state. (DRC0040)
     PropertyNotInDesiredStateMessage = Property '{0}' is not in desired state. (DRC0041)
     NoMatchKeyMessage = NOTMATCH: Value (type '{0}') for property '{1}' does not match. Current state has the key(s) '{2}' and desired state has not. (DRC0042)
-    IsElevated_UserNotElevated = This command must run in an elevated PowerShell session. (DRC0043)
+
+    ## Assert-ElevatedUser
+    ElevatedUser_UserNotElevated = This command must run in an elevated PowerShell session. (DRC0043)
 '@

--- a/tests/Unit/Public/Assert-ElevatedUser.Tests.ps1
+++ b/tests/Unit/Public/Assert-ElevatedUser.Tests.ps1
@@ -62,7 +62,7 @@ Describe 'Assert-ElevatedUser' -Tag 'Private' {
 
     It 'Should throw the correct error' -Skip:$mockIsElevated {
         InModuleScope -ScriptBlock {
-            $mockErrorMessage = $script:localizedData.IsElevated_UserNotElevated
+            $mockErrorMessage = $script:localizedData.ElevatedUser_UserNotElevated
 
             { Assert-ElevatedUser } | Should -Throw -ExpectedMessage $mockErrorMessage
         }


### PR DESCRIPTION
#### Pull Request (PR) description
- `Assert-ElevatedUser`
  - Renamed the localized string key name and prepared the localized string
    file to be able to distinguish which key belong to which command.

#### This Pull Request (PR) fixes the following issues
None. Just cleanup.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated for all new/changed functions.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.common/86)
<!-- Reviewable:end -->
