### PR TITLE
Set-PSModulePath: New parameter set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Tasks for automating documentation for the GitHub repository wiki ([issue #110](https://github.com/dsccommunity/DscResource.Common/issues/110)).
+- `Set-PSModulePath`
+  - A new parameters set takes two parameters `FromTarget` and `ToTarget`
+    that can copy from omne target to the other.
+  - A new parameter `PassThru` that, if specified, returns the path that
+    was set.
 
 ### Changed
 
@@ -17,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Command documentation was moved from README to GitHub repository wiki.
 - Change the word cmdlet to command throughout in the documentation, code
   and localization strings.
+- A meta task now removes the built module from the session if it is imported.
 - `Get-LocalizedData`
   - Refactored to simplify execution and debugging. The command previously
     used a steppable pipeline (proxies `Import-LocalizedData`), that was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tasks for automating documentation for the GitHub repository wiki ([issue #110](https://github.com/dsccommunity/DscResource.Common/issues/110)).
 - `Set-PSModulePath`
   - A new parameters set takes two parameters `FromTarget` and `ToTarget`
-    that can copy from omne target to the other.
+    that can copy from omne target to the other ([issue #102](https://github.com/dsccommunity/DscResource.Common/issues/102)).
   - A new parameter `PassThru` that, if specified, returns the path that
     was set.
 

--- a/build.yaml
+++ b/build.yaml
@@ -19,6 +19,7 @@ BuildWorkflow:
     - test
 
   build:
+    - Remove_BuiltModule_From_Session
     - Clean
     - Build_Module_ModuleBuilder
     - Build_NestedModules_ModuleBuilder
@@ -50,6 +51,11 @@ BuildWorkflow:
     - Publish_release_to_GitHub
     - publish_module_to_gallery
     - Publish_GitHub_Wiki_Content
+
+  Remove_BuiltModule_From_Session: |
+    {
+        Remove-Module -Name 'DscResource.Common' -ErrorAction SilentlyContinue
+    }
 
 ####################################################
 #       PESTER  Configuration                      #

--- a/source/Public/Set-PSModulePath.ps1
+++ b/source/Public/Set-PSModulePath.ps1
@@ -52,6 +52,7 @@ function Set-PSModulePath
         Justification = 'ShouldProcess is not supported in DSC resources.'
     )]
     [CmdletBinding(DefaultParameterSetName = 'Default')]
+    [OutputType([System.String])]
     param
     (
         [Parameter(Mandatory = $true, ParameterSetName = 'Default')]

--- a/tests/Unit/Public/Set-PSModulePath.Tests.ps1
+++ b/tests/Unit/Public/Set-PSModulePath.Tests.ps1
@@ -1,0 +1,98 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:moduleName = 'DscResource.Common'
+
+    # Make sure there are not other modules imported that will conflict with mocks.
+    Get-Module -Name $script:moduleName -All | Remove-Module -Force
+
+    # Re-import the module using force to get any code changes between runs.
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    Remove-Module -Name $script:moduleName
+}
+
+Describe 'Set-PSModulePath' {
+    Context 'When using the parameter set TargetParameters' {
+        Context 'When using FromTarget and ToTarget parameters' {
+            BeforeAll {
+                $originalPSModulePath = $env:PSModulePath
+
+                Mock -CommandName Get-EnvironmentVariable -MockWith {
+                    return '/tmp/path'
+                }
+            }
+
+            AfterAll {
+                $env:PSModulePath = $originalPSModulePath
+            }
+
+            It 'Should not throw an error and have set the correct value' {
+                { Set-PSModulePath -FromTarget 'User' -ToTarget 'Session' } | Should -Not -Throw
+
+                Assert-MockCalled -CommandName Get-EnvironmentVariable -Exactly -Times 1 -Scope It
+
+                [Environment]::GetEnvironmentVariable('PSModulePath') | Should -Be '/tmp/path'
+            }
+
+            It 'Should have returned the user PSModulePath to the original value' {
+                { Set-PSModulePath -Path $originalPSModulePath } | Should -Not -Throw
+
+                [Environment]::GetEnvironmentVariable('PSModulePath') | Should -Be $originalPSModulePath
+            }
+        }
+
+        Context 'When using PassThru parameter' {
+            BeforeAll {
+                $originalPSModulePath = $env:PSModulePath
+            }
+
+            AfterEach {
+                $env:PSModulePath = $originalPSModulePath
+            }
+
+            It 'Should not throw an error and return the correct value' {
+                $result = Set-PSModulePath -Path 'C:\Module' -PassThru
+
+                $result | Should -Be 'C:\Module'
+            }
+
+            It 'Should have set the session PSModulePath to the new value' {
+                $env:PSModulePath | Should -Be $originalPSModulePath
+            }
+        }
+    }
+}


### PR DESCRIPTION

#### Pull Request (PR) description
- `Set-PSModulePath`
  - A new parameters set takes two parameters `FromTarget` and `ToTarget`
    that can copy from omne target to the other (issue #102).
  - A new parameter `PassThru` that, if specified, returns the path that
    was set.
- A meta task now removes the built module from the session if it is imported.

#### This Pull Request (PR) fixes the following issues

- Fixes #102


#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [x] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/DscResource.Common/114)
<!-- Reviewable:end -->
