### PR TITLE
`Assert-ElevatedUser` - Add custom error message parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public command:
   - `Get-UserName` - get current user name cross platform.
 
+### Changed
+
+- `Assert-ElevatedUser`
+  - Add new parameter `ErrorMessage` to allow custom error messages.
+
 ### Fixed
 
 - `Get-PSModulePath`

--- a/source/Public/Assert-ElevatedUser.ps1
+++ b/source/Public/Assert-ElevatedUser.ps1
@@ -34,7 +34,7 @@ function Assert-ElevatedUser
     [CmdletBinding()]
     param (
         [Parameter()]
-        [ValidateNotNullOrWhiteSpace()]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ErrorMessage = $script:localizedData.ElevatedUser_UserNotElevated
     )

--- a/source/Public/Assert-ElevatedUser.ps1
+++ b/source/Public/Assert-ElevatedUser.ps1
@@ -7,8 +7,16 @@
         throw a statement-terminating error if the script is not run from an elevated
         session.
 
+    .PARAMETER ErrorMessage
+        The error message to assign to the exception.
+
     .EXAMPLE
         Assert-ElevatedUser
+
+        Throws an exception if the user has not elevated the PowerShell session.
+
+    .EXAMPLE
+        Assert-ElevatedUser -ErrorMessage 'A custom error message to throw'
 
         Throws an exception if the user has not elevated the PowerShell session.
 
@@ -24,7 +32,12 @@
 function Assert-ElevatedUser
 {
     [CmdletBinding()]
-    param ()
+    param (
+        [Parameter()]
+        [ValidateNotNullOrWhiteSpace()]
+        [System.String]
+        $ErrorMessage = $script:localizedData.ElevatedUser_UserNotElevated
+    )
 
     $isElevated = $false
 
@@ -43,7 +56,7 @@ function Assert-ElevatedUser
     {
         $PSCmdlet.ThrowTerminatingError(
             [System.Management.Automation.ErrorRecord]::new(
-                $script:localizedData.ElevatedUser_UserNotElevated,
+                $ErrorMessage,
                 'UserNotElevated',
                 [System.Management.Automation.ErrorCategory]::InvalidOperation,
                 'Command parameters'

--- a/tests/Unit/Public/Assert-ElevatedUser.Tests.ps1
+++ b/tests/Unit/Public/Assert-ElevatedUser.Tests.ps1
@@ -63,16 +63,33 @@ Describe 'Assert-ElevatedUser' -Tag 'Public' {
         }
     }
 
-    It 'Should throw the correct error' -Skip:$mockIsElevated {
-        $mockErrorMessage = InModuleScope -ScriptBlock {
-            $script:localizedData.ElevatedUser_UserNotElevated
+    Context 'When not supplying an error message' {
+        It 'Should throw the correct error' -Skip:$mockIsElevated {
+            $mockErrorMessage = InModuleScope -ScriptBlock {
+                $script:localizedData.ElevatedUser_UserNotElevated
+            }
+
+            { Assert-ElevatedUser } | Should -Throw -ExpectedMessage $mockErrorMessage
         }
 
-        { Assert-ElevatedUser } | Should -Throw -ExpectedMessage $mockErrorMessage
+        It 'Should not throw an exception' -Skip:(-not $mockIsElevated) {
+            { Assert-ElevatedUser } | Should -Not -Throw
+        }
     }
 
-    It 'Should not throw an exception' -Skip:(-not $mockIsElevated) {
-        { Assert-ElevatedUser } | Should -Not -Throw
+    Context 'When supplying a custom error message' {
+        BeforeAll {
+            $mockCustomMessage = 'This is a custom error message'
+        }
+
+        It 'Should throw the correct error' -Skip:$mockIsElevated {
+            { Assert-ElevatedUser -ErrorMessage $mockCustomMessage } | Should -Throw -ExpectedMessage $mockCustomMessage
+        }
+
+
+        It 'Should not throw an exception' -Skip:(-not $mockIsElevated) {
+            { Assert-ElevatedUser -ErrorMessage $mockCustomMessage} | Should -Not -Throw
+        }
     }
 
     Context 'When on Linux or macOS' {


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure the PR title is short but a descriptive
    summary of the PR,
    e.g "String arrays where not allowed if it had un unsupported value map".

    You may remove this comment block, and the other comment blocks,
    but please keep the headers and the task list.
-->
#### Pull Request (PR) description
<!--
    Replace this comment block with a description of your PR.
-->

Add parameter to `Assert-ElevatedUser` to allow use of custom error messages. Backward compatible with existing as default value is the old error message value. 

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment block with the list of issues or n/a.
    Use format:
    - Fixes #123
    - Fixes #124
-->

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [x] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/DscResource.Common/129)
<!-- Reviewable:end -->
