### PR TITLE
Fix `Get-RegistryPropertyValue` to handle non-existent property safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `Get-RegistryPropertyValue`
+  - Current implementation was not safe and could throw an exception if
+    the property did not exist, even if `-ErrorAction 'SilentlyContinue`
+    was passed. This was fixed by using `Get-ItemProperty` instead of
+    `Get-ItemPropertyValue` ([issue #139](https://github.com/dsccommunity/DscResource.Common/issues/139#issuecomment-2708847681).
+
 ## [0.20.0] - 2025-03-09
 
 ### Added

--- a/source/Public/Get-RegistryPropertyValue.ps1
+++ b/source/Public/Get-RegistryPropertyValue.ps1
@@ -57,7 +57,7 @@ function Get-RegistryPropertyValue
         $ErrorActionPreference = 'SilentlyContinue'
     }
 
-    $getItemPropertyResult = Get-ItemProperty @PSBoundParameters -ErrorAction:$ErrorActionPreference
+    $getItemPropertyResult = Get-ItemProperty -Path $Path -Name $Name -ErrorAction:$ErrorActionPreference
 
     if ($null -ne $getItemPropertyResult)
     {

--- a/source/Public/Get-RegistryPropertyValue.ps1
+++ b/source/Public/Get-RegistryPropertyValue.ps1
@@ -23,6 +23,12 @@
         Returns the value of the property RS at the specified path, and throws an
         exception if either that path or the name does not exist.
 
+    .EXAMPLE
+        Get-RegistryPropertyValue -Path 'HKCU:\SOFTWARE\Microsoft\Wisp\Touch' -Name 'Friction' -ErrorAction 'SilentlyContinue'
+
+        Returns the value of the property Friction at the specified path, and
+        suppresses any errors that may occur if the path or the name does not exist.
+
     .NOTES
         This function is similar to Get-ItemPropertyValue, but this command will
         honor the `-ErrorAction` parameter which Get-ItemPropertyValue does not.
@@ -44,14 +50,20 @@ function Get-RegistryPropertyValue
         $Name
     )
 
-    $getItemPropertyValueResult = $null
+    $getRegistryPropertyValueResult = $null
 
     if (-not $PSBoundParameters.ContainsKey('ErrorAction'))
     {
         $ErrorActionPreference = 'SilentlyContinue'
     }
 
-    $getItemPropertyValueResult = Get-ItemPropertyValue @PSBoundParameters
+    $getItemPropertyResult = Get-ItemProperty @PSBoundParameters -ErrorAction:$ErrorActionPreference
 
-    return $getItemPropertyValueResult
+    if ($null -ne $getItemPropertyResult)
+    {
+        # If the property name is not found, Get-ItemProperty will return $null.
+        $getRegistryPropertyValueResult = $getItemPropertyResult.$Name
+    }
+
+    return $getRegistryPropertyValueResult
 }


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure the PR title is short but a descriptive
    summary of the PR,
    e.g "String arrays where not allowed if it had un unsupported value map".

    You may remove this comment block, and the other comment blocks,
    but please keep the headers and the task list.
-->
- `Get-RegistryPropertyValue`
  - Current implementation was not safe and could throw an exception if
    the property did not exist, even if `-ErrorAction 'SilentlyContinue`
    was passed. This was fixed by using `Get-ItemProperty` instead of
    `Get-ItemPropertyValue` ([issue #139](https://github.com/dsccommunity/DscResource.Common/issues/139#issuecomment-2708847681).

#### This Pull Request (PR) fixes the following issues
- Fixes #139

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [x] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/DscResource.Common/143)
<!-- Reviewable:end -->
