### PR TITLE
`Test-PendingRestart`: New command to check for pending restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `Get-FileProductVersion` - Get the product version of a file.
     - `Test-PendingRestart` - Test if a pending restart is required.
 
+### Fixed
+
+- Updated multiple test scripts to redirect standard output using file
+  descriptor 3 instead of 2, ensuring that error streams remain unaffected
+  while suppressing other output.
+
 ## [0.21.0] - 2025-03-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DscResource.Common
   - Public command:
     - `Get-FileProductVersion` - Get the product version of a file.
+    - `Test-PendingRestart` - Test if a pending restart is required.
+
+## [0.21.0] - 2025-03-16
+
+### Added
+
+- DscResource.Common
+  - Public command:
+    - `Format-Path` - Format a file system path based on the operating
+       system and specified parameters.
 
 ## [0.20.1] - 2025-03-10
 

--- a/source/Enum/PendingRestartCheck.ps1
+++ b/source/Enum/PendingRestartCheck.ps1
@@ -1,0 +1,11 @@
+[Flags()]
+enum PendingRestartCheck
+{
+    ComponentBasedServicing = 1
+    WindowsUpdate = 2
+    PendingFileRename = 4
+    PendingComputerRename = 8
+    PendingDomainJoin = 16
+    ConfigurationManagerClient = 32
+    All = 63 # Sum of all values above
+}

--- a/source/Public/Test-PendingRestart.ps1
+++ b/source/Public/Test-PendingRestart.ps1
@@ -1,0 +1,160 @@
+<#
+    .SYNOPSIS
+        Tests if the computer is pending a restart.
+
+    .DESCRIPTION
+        This function checks various registry locations, the Component-Based
+        Servicing, Windows Update, Pending File Rename Operations, Pending Computer
+        Rename, Pending Domain Join, and SCCM Client to determine if the computer
+        is pending a restart.
+
+    .PARAMETER Check
+        Specifies which pending restart checks to perform. Multiple values can be
+        specified by using the bitwise OR operator. By default, all checks are performed.
+
+        Available options are:
+        - ComponentBasedServicing: Checks Component-Based Servicing registry key
+        - WindowsUpdate: Checks Windows Update Auto Update registry key
+        - PendingFileRename: Checks PendingFileRenameOperations registry key
+        - PendingComputerRename: Checks for pending computer rename
+        - PendingDomainJoin: Checks for pending domain join
+        - ConfigurationManagerClient: Checks Configuration Manager client for pending reboots
+        - All: Performs all checks (default)
+
+    .EXAMPLE
+        Test-PendingRestart
+
+        Returns $true if the computer is pending a restart, otherwise returns $false.
+
+    .EXAMPLE
+        Test-PendingRestart -Check WindowsUpdate, ComponentBasedServicing
+
+        Checks only Windows Update and Component-Based Servicing for pending restarts.
+        Returns $true if either condition requires a restart, otherwise returns $false.
+
+    .OUTPUTS
+        [System.Boolean]
+
+    .NOTES
+        This command checks for the following conditions:
+        - Windows Update Auto Update (RebootRequired)
+        - Component-Based Servicing (RebootPending)
+        - Pending File Rename Operations
+        - Pending Computer Rename
+        - Pending Domain Join
+        - Pending SCCM Client Reboot
+#>
+function Test-PendingRestart
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter()]
+        [PendingRestartCheck]
+        $Check = [PendingRestartCheck]::All
+    )
+
+    # cSpell:ignore SCCM
+    if ($IsWindows -or $PSEdition -eq 'Desktop')
+    {
+        $pendingRestart = $false
+        $cbsRebootPending = $false
+        $windowsUpdateRebootRequired = $false
+        $pendingFileRename = $false
+        $pendingComputerRename = $false
+        $pendingDomainJoin = $false
+        $pendingCcmReboot = $false
+
+        # Check Component-Based Servicing (CBS) registry key.
+        if ($Check -band [PendingRestartCheck]::ComponentBasedServicing)
+        {
+            $getRegistryPropertyValueParameters = @{
+                Path = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending'
+                Name = '*'
+            }
+
+            $cbsRebootPending = $null -ne (Get-RegistryPropertyValue @getRegistryPropertyValueParameters)
+        }
+
+        # Check Windows Update Auto Update registry key.
+        if ($Check -band [PendingRestartCheck]::WindowsUpdate)
+        {
+            $getRegistryPropertyValueParameters = @{
+                Path = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired'
+                Name = '*'
+            }
+
+            $windowsUpdateRebootRequired = $null -ne (Get-RegistryPropertyValue @getRegistryPropertyValueParameters)
+        }
+
+        <#
+            Check PendingFileRenameOperations registry key. If the key 'PendingFileRenameOperations'
+            does not exist then it should return $false, otherwise it should return $true.
+        #>
+        if ($Check -band [PendingRestartCheck]::PendingFileRename)
+        {
+            $getRegistryPropertyValueParameters = @{
+                Path = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager'
+                Name = 'PendingFileRenameOperations'
+            }
+
+            $pendingFileRename = $null -ne (Get-RegistryPropertyValue @getRegistryPropertyValueParameters)
+        }
+
+        # Check for pending computer rename.
+        if ($Check -band [PendingRestartCheck]::PendingComputerRename)
+        {
+            $activeComputerName = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName' -Name 'ComputerName' -ErrorAction 'SilentlyContinue'
+            $pendingComputerName = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName' -Name 'ComputerName' -ErrorAction 'SilentlyContinue'
+
+            if ($activeComputerName -and $pendingComputerName)
+            {
+                $pendingComputerRename = $activeComputerName.ComputerName -ne $pendingComputerName.ComputerName
+            }
+        }
+
+        # Check for pending domain join. cSpell:ignore Netlogon
+        if ($Check -band [PendingRestartCheck]::PendingDomainJoin)
+        {
+            $getRegistryPropertyValueParameters = @{
+                Path = 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon'
+                Name = 'JoinDomain'
+            }
+
+            $pendingDomainJoin = $null -ne (Get-RegistryPropertyValue @getRegistryPropertyValueParameters)
+        }
+
+        # Check Configuration Manager client.
+        if ($Check -band [PendingRestartCheck]::ConfigurationManagerClient)
+        {
+            $getRegistryPropertyValueParameters = @{
+                Path = 'HKLM:\SOFTWARE\Microsoft\SMS\Mobile Client\Reboot Management\RebootData'
+                Name = '*'
+            }
+
+            $pendingCcmReboot = $null -ne (Get-RegistryPropertyValue @getRegistryPropertyValueParameters)
+        }
+
+        # If any of the above criteria are true, set pendingRestart to true
+        if ($cbsRebootPending -or $windowsUpdateRebootRequired -or $pendingFileRename -or $pendingComputerRename -or $pendingDomainJoin -or $pendingCcmReboot)
+        {
+            $pendingRestart = $true
+        }
+
+        return $pendingRestart
+    }
+    else
+    {
+        $writeErrorParameters = @{
+            Message      = $script:localizedData.Test_PendingRestart_UnsupportedOs
+            Category     = 'InvalidOperation'
+            ErrorId      = 'TPR0001' # cSpell: disable-line
+            TargetObject = $DatabaseName
+        }
+
+        Write-Error @writeErrorParameters
+
+        return $false
+    }
+}

--- a/source/Public/Test-PendingRestart.ps1
+++ b/source/Public/Test-PendingRestart.ps1
@@ -46,6 +46,7 @@
 #>
 function Test-PendingRestart
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('UseSyntacticallyCorrectExamples', '', Justification = 'Because the rule does not yet support parsing the code when a parameter type is not available. The ScriptAnalyzer rule UseSyntacticallyCorrectExamples will always error in the editor due to https://github.com/indented-automation/Indented.ScriptAnalyzerRules/issues/8.')]
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param

--- a/source/en-US/DscResource.Common.strings.psd1
+++ b/source/en-US/DscResource.Common.strings.psd1
@@ -58,4 +58,7 @@ ConvertFrom-StringData @'
 
     # Format-Path
     Format_Path_NormalizedPath = Path normalization completed. Original: '{0}', Normalized: '{1}'. (DRC0054)
+
+    ## Test-PendingRestart
+    Test_PendingRestart_UnsupportedOs = Unsupported on non-Windows platforms. (DRC0055)
 '@

--- a/tests/Unit/Private/Assert-RequiredCommandParameter.Tests.ps1
+++ b/tests/Unit/Private/Assert-RequiredCommandParameter.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Private/Test-DscObjectHasProperty.Tests.ps1
+++ b/tests/Unit/Private/Test-DscObjectHasProperty.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Private/Test-DscPropertyIsAssigned.Tests.ps1
+++ b/tests/Unit/Private/Test-DscPropertyIsAssigned.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Private/Test-DscPropertyState.Tests.ps1
+++ b/tests/Unit/Private/Test-DscPropertyState.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Assert-ElevatedUser.Tests.ps1
+++ b/tests/Unit/Public/Assert-ElevatedUser.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Assert-IPAddress.Tests.ps1
+++ b/tests/Unit/Public/Assert-IPAddress.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Assert-Module.Tests.ps1
+++ b/tests/Unit/Public/Assert-Module.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Compare-DscParameterState.Tests.ps1
+++ b/tests/Unit/Public/Compare-DscParameterState.Tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Compare-ResourcePropertyState.Tests.ps1
+++ b/tests/Unit/Public/Compare-ResourcePropertyState.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/ConvertFrom-DscResourceInstance.Tests.ps1
+++ b/tests/Unit/Public/ConvertFrom-DscResourceInstance.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/ConvertTo-CimInstance.Tests.ps1
+++ b/tests/Unit/Public/ConvertTo-CimInstance.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/ConvertTo-Hashtable.Tests.ps1
+++ b/tests/Unit/Public/ConvertTo-Hashtable.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Find-Certificate.Tests.ps1
+++ b/tests/Unit/Public/Find-Certificate.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Format-Path.Tests.ps1
+++ b/tests/Unit/Public/Format-Path.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Get-ComputerName.Tests.ps1
+++ b/tests/Unit/Public/Get-ComputerName.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Get-DscProperty.Tests.ps1
+++ b/tests/Unit/Public/Get-DscProperty.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Get-EnvironmentVariable.Tests.ps1
+++ b/tests/Unit/Public/Get-EnvironmentVariable.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Get-LocalizedData.Tests.ps1
+++ b/tests/Unit/Public/Get-LocalizedData.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Get-LocalizedDataForInvariantCulture.Tests.ps1
+++ b/tests/Unit/Public/Get-LocalizedDataForInvariantCulture.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Get-PSModulePath.Tests.ps1
+++ b/tests/Unit/Public/Get-PSModulePath.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Get-RegistryPropertyValue.Tests.ps1
+++ b/tests/Unit/Public/Get-RegistryPropertyValue.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Get-TemporaryFolder.Tests.ps1
+++ b/tests/Unit/Public/Get-TemporaryFolder.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Get-UserName.Tests.ps1
+++ b/tests/Unit/Public/Get-UserName.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/New-ArgumentException.Tests.ps1
+++ b/tests/Unit/Public/New-ArgumentException.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/New-ErrorRecord.Tests.ps1
+++ b/tests/Unit/Public/New-ErrorRecord.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/New-Exception.Tests.ps1
+++ b/tests/Unit/Public/New-Exception.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/New-InvalidDataException.Tests.ps1
+++ b/tests/Unit/Public/New-InvalidDataException.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/New-InvalidOperationException.Tests.ps1
+++ b/tests/Unit/Public/New-InvalidOperationException.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/New-InvalidResultException.Tests.ps1
+++ b/tests/Unit/Public/New-InvalidResultException.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/New-NotImplementedException.Tests.ps1
+++ b/tests/Unit/Public/New-NotImplementedException.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/New-ObjectNotFoundException.Tests.ps1
+++ b/tests/Unit/Public/New-ObjectNotFoundException.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Remove-CommonParameter.Tests.ps1
+++ b/tests/Unit/Public/Remove-CommonParameter.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Set-PSModulePath.Tests.ps1
+++ b/tests/Unit/Public/Set-PSModulePath.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Test-AccountRequirePassword.Tests.ps1
+++ b/tests/Unit/Public/Test-AccountRequirePassword.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Test-DscParameterState.Tests.ps1
+++ b/tests/Unit/Public/Test-DscParameterState.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Test-DscProperty.Tests.ps1
+++ b/tests/Unit/Public/Test-DscProperty.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Test-IsNanoServer.Tests.ps1
+++ b/tests/Unit/Public/Test-IsNanoServer.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Test-IsNumericType.Tests.ps1
+++ b/tests/Unit/Public/Test-IsNumericType.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Test-ModuleExist.Tests.ps1
+++ b/tests/Unit/Public/Test-ModuleExist.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Test-PendingRestart.Tests.ps1
+++ b/tests/Unit/Public/Test-PendingRestart.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Test-PendingRestart.Tests.ps1
+++ b/tests/Unit/Public/Test-PendingRestart.Tests.ps1
@@ -1,0 +1,266 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:moduleName = 'DscResource.Common'
+
+    # Make sure there are not other modules imported that will conflict with mocks.
+    Get-Module -Name $script:moduleName -All | Remove-Module -Force
+
+    # Re-import the module using force to get any code changes between runs.
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    Remove-Module -Name $script:moduleName
+}
+
+Describe 'Test-PendingRestart' -Skip:($IsLinux -or $IsMacOS) {
+    BeforeAll {
+        InModuleScope -ScriptBlock {
+            # Define PendingRestartCheck enum if not already defined in the test context
+            if (-not ('PendingRestartCheck' -as [Type]))
+            {
+                Add-Type -TypeDefinition @'
+                [System.Flags()]
+                public enum PendingRestartCheck
+                {
+                    ComponentBasedServicing = 1,
+                    WindowsUpdate = 2,
+                    PendingFileRename = 4,
+                    PendingComputerRename = 8,
+                    PendingDomainJoin = 16,
+                    ConfigurationManagerClient = 32,
+                    All = 63
+                }
+'@
+            }
+        }
+
+        # Mock the function to handle platform detection
+        Mock -CommandName Get-Variable -MockWith { return $true } -ParameterFilter { $Name -eq 'IsWindows' }
+        Mock -CommandName Get-Variable -MockWith { return 'Desktop' } -ParameterFilter { $Name -eq 'PSEdition' }
+
+        # Mock Get-RegistryPropertyValue
+        Mock -CommandName Get-RegistryPropertyValue -MockWith { return $null }
+
+        # Mock Get-ItemProperty
+        Mock -CommandName Get-ItemProperty -MockWith {
+            return New-Object -TypeName PSObject -Property @{
+                ComputerName = 'TESTCOMPUTER'
+            }
+        }
+    }
+
+    Context 'When running on a non-Windows system' {
+        BeforeAll {
+            Mock -CommandName Get-Variable -MockWith { return $false } -ParameterFilter { $Name -eq 'IsWindows' }
+            Mock -CommandName Get-Variable -MockWith { return 'Core' } -ParameterFilter { $Name -eq 'PSEdition' }
+            Mock -CommandName Write-Error
+        }
+
+        It 'Should write an error and return $false' {
+            Test-PendingRestart | Should -BeFalse
+            Should -Invoke -CommandName Write-Error -Times 1 -Exactly
+        }
+    }
+
+    Context 'When all checks return no pending restart' {
+        BeforeAll {
+            Mock -CommandName Get-RegistryPropertyValue -MockWith { return $null }
+
+            Mock -CommandName Get-ItemProperty -MockWith {
+                if ($Path -match 'ActiveComputerName$')
+                {
+                    return @{ ComputerName = 'COMPUTER1' }
+                }
+                elseif ($Path -match 'ComputerName$')
+                {
+                    return @{ ComputerName = 'COMPUTER1' }
+                }
+            }
+        }
+
+        It 'Should return $false' {
+            Test-PendingRestart | Should -BeFalse
+        }
+    }
+
+    Context 'When ComponentBasedServicing check returns pending restart' {
+        BeforeAll {
+            Mock -CommandName Get-RegistryPropertyValue -MockWith {
+                if ($Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending')
+                {
+                    return @{ RebootPending = 1 }
+                }
+                return $null
+            }
+        }
+
+        It 'Should return $true' {
+            Test-PendingRestart | Should -BeTrue
+        }
+
+        It 'Should return $true when only ComponentBasedServicing check is specified' {
+            Test-PendingRestart -Check ([PendingRestartCheck]::ComponentBasedServicing) | Should -BeTrue
+        }
+
+        It 'Should return $false when only WindowsUpdate check is specified' {
+            Test-PendingRestart -Check ([PendingRestartCheck]::WindowsUpdate) | Should -BeFalse
+        }
+    }
+
+    Context 'When WindowsUpdate check returns pending restart' {
+        BeforeAll {
+            Mock -CommandName Get-RegistryPropertyValue -MockWith {
+                if ($Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired')
+                {
+                    return @{ RebootRequired = 1 }
+                }
+                return $null
+            }
+        }
+
+        It 'Should return $true' {
+            Test-PendingRestart | Should -BeTrue
+        }
+
+        It 'Should return $false when only ComponentBasedServicing check is specified' {
+            Test-PendingRestart -Check ([PendingRestartCheck]::ComponentBasedServicing) | Should -BeFalse
+        }
+
+        It 'Should return $true when only WindowsUpdate check is specified' {
+            Test-PendingRestart -Check ([PendingRestartCheck]::WindowsUpdate) | Should -BeTrue
+        }
+    }
+
+    Context 'When PendingFileRename check returns pending restart' {
+        BeforeAll {
+            Mock -CommandName Get-RegistryPropertyValue -MockWith {
+                if ($Path -eq 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager' -and $Name -eq 'PendingFileRenameOperations')
+                {
+                    return @{ PendingFileRenameOperations = @('file1', 'file2') }
+                }
+                return $null
+            }
+        }
+
+        It 'Should return $true' {
+            Test-PendingRestart | Should -BeTrue
+        }
+
+        It 'Should return $true when only PendingFileRename check is specified' {
+            Test-PendingRestart -Check ([PendingRestartCheck]::PendingFileRename) | Should -BeTrue
+        }
+    }
+
+    Context 'When PendingComputerRename check returns pending restart' {
+        BeforeAll {
+            Mock -CommandName Get-ItemProperty -MockWith {
+                if ($Path -match 'ActiveComputerName$')
+                {
+                    return @{ ComputerName = 'COMPUTER1' }
+                }
+                elseif ($Path -match 'ComputerName$')
+                {
+                    return @{ ComputerName = 'COMPUTER2' }
+                }
+                return $null
+            }
+        }
+
+        It 'Should return $true' {
+            Test-PendingRestart | Should -BeTrue
+        }
+
+        It 'Should return $true when only PendingComputerRename check is specified' {
+            Test-PendingRestart -Check ([PendingRestartCheck]::PendingComputerRename) | Should -BeTrue
+        }
+    }
+
+    Context 'When PendingDomainJoin check returns pending restart' {
+        BeforeAll {
+            Mock -CommandName Get-RegistryPropertyValue -MockWith {
+                if ($Path -eq 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon' -and $Name -eq 'JoinDomain')
+                {
+                    return @{ JoinDomain = 1 }
+                }
+                return $null
+            }
+        }
+
+        It 'Should return $true' {
+            Test-PendingRestart | Should -BeTrue
+        }
+
+        It 'Should return $true when only PendingDomainJoin check is specified' {
+            Test-PendingRestart -Check ([PendingRestartCheck]::PendingDomainJoin) | Should -BeTrue
+        }
+    }
+
+    Context 'When ConfigurationManagerClient check returns pending restart' {
+        BeforeAll {
+            Mock -CommandName Get-RegistryPropertyValue -MockWith {
+                if ($Path -eq 'HKLM:\SOFTWARE\Microsoft\SMS\Mobile Client\Reboot Management\RebootData')
+                {
+                    return @{ RebootData = 1 }
+                }
+                return $null
+            }
+        }
+
+        It 'Should return $true' {
+            Test-PendingRestart | Should -BeTrue
+        }
+
+        It 'Should return $true when only ConfigurationManagerClient check is specified' {
+            Test-PendingRestart -Check ([PendingRestartCheck]::ConfigurationManagerClient) | Should -BeTrue
+        }
+    }
+
+    Context 'When multiple checks are specified' {
+        BeforeAll {
+            Mock -CommandName Get-RegistryPropertyValue -MockWith {
+                if ($Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired')
+                {
+                    return @{ RebootRequired = 1 }
+                }
+                return $null
+            }
+        }
+
+        It 'Should return $true when one of the checks returns true' {
+            Test-PendingRestart -Check ([PendingRestartCheck]::WindowsUpdate -bor [PendingRestartCheck]::ComponentBasedServicing) | Should -BeTrue
+        }
+    }
+}

--- a/tests/Unit/Public/Test-PendingRestart.Tests.ps1
+++ b/tests/Unit/Public/Test-PendingRestart.Tests.ps1
@@ -95,7 +95,7 @@ Describe 'Test-PendingRestart' {
         }
     }
 
-    Context 'When ComponentBasedServicing check returns pending restart' {
+    Context 'When ComponentBasedServicing check returns pending restart' -Skip:($IsLinux -or $IsMacOS) {
         BeforeAll {
             Mock -CommandName Get-RegistryPropertyValue -MockWith {
                 if ($Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending')
@@ -130,7 +130,7 @@ Describe 'Test-PendingRestart' {
         }
     }
 
-    Context 'When WindowsUpdate check returns pending restart' {
+    Context 'When WindowsUpdate check returns pending restart' -Skip:($IsLinux -or $IsMacOS) {
         BeforeAll {
             Mock -CommandName Get-RegistryPropertyValue -MockWith {
                 if ($Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired')
@@ -165,7 +165,7 @@ Describe 'Test-PendingRestart' {
         }
     }
 
-    Context 'When PendingFileRename check returns pending restart' {
+    Context 'When PendingFileRename check returns pending restart' -Skip:($IsLinux -or $IsMacOS) {
         BeforeAll {
             Mock -CommandName Get-RegistryPropertyValue -MockWith {
                 if ($Path -eq 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager' -and $Name -eq 'PendingFileRenameOperations')
@@ -192,7 +192,7 @@ Describe 'Test-PendingRestart' {
         }
     }
 
-    Context 'When PendingComputerRename check returns pending restart' {
+    Context 'When PendingComputerRename check returns pending restart' -Skip:($IsLinux -or $IsMacOS) {
         BeforeAll {
             Mock -CommandName Get-ItemProperty -MockWith {
                 if ($Path -match 'ActiveComputerName$')
@@ -225,7 +225,7 @@ Describe 'Test-PendingRestart' {
         }
     }
 
-    Context 'When PendingDomainJoin check returns pending restart' {
+    Context 'When PendingDomainJoin check returns pending restart' -Skip:($IsLinux -or $IsMacOS) {
         BeforeAll {
             Mock -CommandName Get-RegistryPropertyValue -MockWith {
                 # cSpell:ignore Netlogon
@@ -253,7 +253,7 @@ Describe 'Test-PendingRestart' {
         }
     }
 
-    Context 'When ConfigurationManagerClient check returns pending restart' {
+    Context 'When ConfigurationManagerClient check returns pending restart' -Skip:($IsLinux -or $IsMacOS) {
         BeforeAll {
             Mock -CommandName Get-RegistryPropertyValue -MockWith {
                 if ($Path -eq 'HKLM:\SOFTWARE\Microsoft\SMS\Mobile Client\Reboot Management\RebootData')
@@ -280,7 +280,7 @@ Describe 'Test-PendingRestart' {
         }
     }
 
-    Context 'When multiple checks are specified' {
+    Context 'When multiple checks are specified' -Skip:($IsLinux -or $IsMacOS) {
         BeforeAll {
             Mock -CommandName Get-RegistryPropertyValue -MockWith {
                 if ($Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired')


### PR DESCRIPTION

#### Pull Request (PR) description
- DscResource.Common
  - Public command:
    - `Test-PendingRestart` - Test if a pending restart is required.

#### This Pull Request (PR) fixes the following issues
None. Moving command from SqlServerDsc

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [x] Comment-based help added/updated for all new/changed functions.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/DscResource.Common/146)
<!-- Reviewable:end -->
