### PR TITLE
`Get-FileProductVersion`: Add public command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove the patch workaround in the pipeline for the ModuleBuilder bug.
+
 ### Added
 
 - DscResource.Common

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- DscResource.Common
+  - Public command:
+    - `Get-FileProductVersion` - Get the product version of a file.
+
 ## [0.20.1] - 2025-03-10
 
 ### Fixed

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,17 +43,6 @@ stages:
               pwsh: true
             env:
               ModuleVersion: $(NuGetVersionV2)
-          - task: PowerShell@2
-            name: patch_module
-            displayName: 'Patch module ModuleBuilder'
-            inputs:
-              targetType: 'inline'
-              script: |
-                ./build.ps1 -Task noop
-                Install-PSResource -Name Viscalyx.Common -Repository PSGallery -TrustRepository -Quiet -Confirm:$false
-                Import-Module -Name Viscalyx.Common
-                Install-ModulePatch -Uri https://raw.githubusercontent.com/viscalyx/Viscalyx.Common/refs/heads/main/patches/ModuleBuilder_3.1.7_patch.json -Force
-              pwsh: true
           - task: PublishPipelineArtifact@1
             displayName: 'Publish Build Artifact'
             inputs:

--- a/source/Public/Get-FileProductVersion.ps1
+++ b/source/Public/Get-FileProductVersion.ps1
@@ -1,0 +1,40 @@
+<#
+    .SYNOPSIS
+        Gets the product version of a file.
+
+    .DESCRIPTION
+        Gets the product version of a file and returns it as a System.Version object.
+        This can be useful for checking the version of installed components or binaries.
+
+    .PARAMETER Path
+        The path to the file to get the product version from.
+
+    .EXAMPLE
+        Get-FileProductVersion -Path 'C:\Temp\setup.exe'
+
+        Returns the product version of the file setup.exe as a System.Version object.
+#>
+function Get-FileProductVersion
+{
+    [CmdletBinding()]
+    [OutputType([System.Version])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Path
+    )
+
+    try
+    {
+        $fileItem = Get-Item -Path $Path -ErrorAction 'Stop'
+
+        return [System.Version] $fileItem.VersionInfo.ProductVersion
+    }
+    catch
+    {
+        $errorMessage = $script:localizedData.Get_FileProductVersion_GetFileProductVersionError -f $Path, $_.Exception.Message
+
+        Write-Error -Message $errorMessage
+    }
+}

--- a/source/en-US/DscResource.Common.strings.psd1
+++ b/source/en-US/DscResource.Common.strings.psd1
@@ -50,6 +50,9 @@ ConvertFrom-StringData @'
     CertificatePathError = Certificate Path '{0}' is not valid. (DRC0046)
     SearchingForCertificateUsingFilters = Looking for certificate in Store '{0}' using filter '{1}'. (DRC0047)
 
+    ## Get-FileProductVersion
+    Get_FileProductVersion_GetFileProductVersionError = Failed to get product version for file '{0}'. Error: {1}
+
     ## Get-PSModulePath
     PSModulePath_MissingMyDocumentsPath = The My Documents folder does not exist for user '{0}'. (DRC0048)
 

--- a/tests/Unit/Public/Get-FileProductVersion.Tests.ps1
+++ b/tests/Unit/Public/Get-FileProductVersion.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Public/Get-FileProductVersion.Tests.ps1
+++ b/tests/Unit/Public/Get-FileProductVersion.Tests.ps1
@@ -1,0 +1,90 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:moduleName = 'DscResource.Common'
+
+    # Make sure there are not other modules imported that will conflict with mocks.
+    Get-Module -Name $script:moduleName -All | Remove-Module -Force
+
+    # Re-import the module using force to get any code changes between runs.
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    Remove-Module -Name $script:moduleName
+}
+
+Describe 'Get-FileProductVersion' {
+    Context 'When the file exists and has a product version' {
+        BeforeAll {
+            Mock -CommandName Get-Item -MockWith {
+                return [PSCustomObject] @{
+                    Exists      = $true
+                    VersionInfo = [PSCustomObject] @{
+                        ProductVersion = '15.0.2000.5'
+                    }
+                }
+            }
+        }
+
+        It 'Should return the correct product version as a System.Version object' {
+            $result = Get-FileProductVersion -Path (Join-Path -Path $TestDrive -ChildPath 'testfile.dll')
+            $result | Should -BeOfType [System.Version]
+            $result.Major | Should -Be 15
+            $result.Minor | Should -Be 0
+            $result.Build | Should -Be 2000
+            $result.Revision | Should -Be 5
+        }
+    }
+
+    Context 'When Get-Item throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-Item -MockWith {
+                throw 'Mock exception message'
+            }
+        }
+
+        It 'Should throw the correct error' {
+            $mockFilePath = Join-Path -Path $TestDrive -ChildPath 'testfile.dll'
+
+            $mockGetFileProductVersionErrorMessage = InModuleScope -ScriptBlock {
+                $script:localizedData.Get_FileProductVersion_GetFileProductVersionError
+            }
+
+            {
+                Get-FileProductVersion -Path $mockFilePath -ErrorAction 'Stop'
+            } | Should -Throw ($mockGetFileProductVersionErrorMessage -f $mockFilePath, 'Mock exception message')
+        }
+    }
+}


### PR DESCRIPTION
#### Pull Request (PR) description
- DscResource.Common
  - Public command:
    - `Get-FileProductVersion` - Get the product version of a file.

#### This Pull Request (PR) fixes the following issues
None. Helps with review comment for PR https://github.com/dsccommunity/SqlServerDsc/pull/2083

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [x] Comment-based help added/updated for all new/changed functions.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/DscResource.Common/148)
<!-- Reviewable:end -->
