### PR TITLE
`Format-Path` add `ExpandEnvironmentVariable` Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Format-Path`
+  - Added parameter `ExpandEnvironmentVariable` fixes [#147](https://github.com/dsccommunity/DscResource.Common/issues/147).
+
 ## [0.22.0] - 2025-04-25
 
 ### Removed

--- a/source/Public/Format-Path.ps1
+++ b/source/Public/Format-Path.ps1
@@ -27,6 +27,11 @@
         When specified, removes any trailing directory separator (backslash) from
         paths, including drive letters.
 
+    .PARAMETER ExpandEnvironmentVariable
+        Replaces the name of each environment variable embedded in the specified string
+        with the string equivalent of the value of the variable.
+        Each environment variable must be quoted with the percent sign character (%).
+
     .EXAMPLE
         Format-Path -Path 'C:/MyFolder/'
 
@@ -65,6 +70,11 @@
 
         Returns '/var/log' on Linux/macOS or '\var\log' on Windows.
         Unix-style absolute paths are normalized to use the system's directory separator.
+
+    .EXAMPLE
+        Format-Path -Path '%WinDir%\SubFolder' -ExpandEnvironmentVariable
+
+        Returns the path with the environment variable expanded, e.g., 'C:\Windows\SubFolder'
 #>
 function Format-Path
 {
@@ -82,7 +92,11 @@ function Format-Path
 
         [Parameter()]
         [System.Management.Automation.SwitchParameter]
-        $NoTrailingDirectorySeparator
+        $NoTrailingDirectorySeparator,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ExpandEnvironmentVariable
     )
 
     if ($Path -match '^(?:[a-zA-Z]:|\\\\)')
@@ -114,6 +128,11 @@ function Format-Path
             # Insert missing backslash after drive letter if needed (e.g., 'C:temp' -> 'C:\temp').
             $normalizedPath = $normalizedPath -replace '^([a-zA-Z]:)', '$1\'
         }
+    }
+
+    if ($ExpandEnvironmentVariable)
+    {
+        $normalizedPath = [System.Environment]::ExpandEnvironmentVariables($normalizedPath)
     }
 
     Write-Debug -Message ($script:localizedData.Format_Path_NormalizedPath -f $Path, $normalizedPath)

--- a/source/Public/Format-Path.ps1
+++ b/source/Public/Format-Path.ps1
@@ -99,14 +99,22 @@ function Format-Path
         $ExpandEnvironmentVariable
     )
 
-    if ($Path -match '^(?:[a-zA-Z]:|\\\\)')
+    # Use local variable so it always exists.
+    $normalizedPath = $Path
+
+    if ($ExpandEnvironmentVariable)
+    {
+        $normalizedPath = [System.Environment]::ExpandEnvironmentVariables($normalizedPath)
+    }
+
+    if ($normalizedPath -match '^(?:[a-zA-Z]:|\\\\)')
     {
         # Path starts with a Windows drive letter, normalize to backslashes.
-        $normalizedPath = $Path -replace '/', '\'
+        $normalizedPath = $normalizedPath -replace '/', '\'
     }
     else
     {
-        $normalizedPath = $Path -replace '[\\|/]', [System.IO.Path]::DirectorySeparatorChar
+        $normalizedPath = $normalizedPath -replace '[\\|/]', [System.IO.Path]::DirectorySeparatorChar
     }
 
     # Remove trailing backslash if parameter is specified and path is not just a drive root.
@@ -128,11 +136,6 @@ function Format-Path
             # Insert missing backslash after drive letter if needed (e.g., 'C:temp' -> 'C:\temp').
             $normalizedPath = $normalizedPath -replace '^([a-zA-Z]:)', '$1\'
         }
-    }
-
-    if ($ExpandEnvironmentVariable)
-    {
-        $normalizedPath = [System.Environment]::ExpandEnvironmentVariables($normalizedPath)
     }
 
     Write-Debug -Message ($script:localizedData.Format_Path_NormalizedPath -f $Path, $normalizedPath)

--- a/tests/Unit/Public/Format-Path.Tests.ps1
+++ b/tests/Unit/Public/Format-Path.Tests.ps1
@@ -172,7 +172,7 @@ Describe 'Format-Path' {
             Format-Path -Path '%TestPath%' -ExpandEnvironmentVariable | Should -Be 'C:\TestFolder'
         }
 
-        It 'Should handle paths with multiple environment variables' {
+        It 'Should handle paths with multiple environment variables' -Skip:($IsLinux -or $IsMacOS) {
             $env:BasePath = 'C:\Base'
             $env:SubPath = 'SubFolder'
             Format-Path -Path '%BasePath%\%SubPath%' -ExpandEnvironmentVariable | Should -Be 'C:\Base\SubFolder'

--- a/tests/Unit/Public/Format-Path.Tests.ps1
+++ b/tests/Unit/Public/Format-Path.Tests.ps1
@@ -165,4 +165,21 @@ Describe 'Format-Path' {
             }
         }
     }
+
+    Context 'When using ExpandEnvironmentVariable parameter' {
+        It 'Should expand environment variables in the path' {
+            $env:TestPath = 'C:\TestFolder'
+            Format-Path -Path '%TestPath%' -ExpandEnvironmentVariable | Should -Be 'C:\TestFolder'
+        }
+
+        It 'Should handle paths with multiple environment variables' {
+            $env:BasePath = 'C:\Base'
+            $env:SubPath = 'SubFolder'
+            Format-Path -Path '%BasePath%\%SubPath%' -ExpandEnvironmentVariable | Should -Be 'C:\Base\SubFolder'
+        }
+
+        It 'Should not modify paths without environment variables' {
+            Format-Path -Path 'C:\NoEnvVar' -ExpandEnvironmentVariable | Should -Be 'C:\NoEnvVar'
+        }
+    }
 }


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure the PR title is short but a descriptive
    summary of the PR,
    e.g "String arrays where not allowed if it had un unsupported value map".

    You may remove this comment block, and the other comment blocks,
    but please keep the headers and the task list.
-->
#### Pull Request (PR) description
<!--
    Replace this comment block with a description of your PR.
-->

Add `ExpandEnvironmentVariable` to `Format-Path`. 

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment block with the list of issues or n/a.
    Use format:
    - Fixes #123
    - Fixes #124
-->

- Fixes #147 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [x] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/DscResource.Common/152)
<!-- Reviewable:end -->
