### PR TITLE
`Assert-BoundParameter`: Move `IfEqualParameterList` into `IfParameterPresent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,18 +16,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added parameter `IfEqualParameterList` to conditionally perform assertions
     only when specified parameters have exact values [#160](https://github.com/dsccommunity/DscResource.Common/issues/160).
 - `Format-Path`
-  - Added parameter `ExpandEnvironmentVariable` fixes [#147](https://github.com/dsccommunity/DscResource.Common/issues/147).
-  - Added support to `Compare-DscParameterState` for comparing large hashtables
-    that contain lists of elements.
+  - Added parameter `ExpandEnvironmentVariable` (issue [#147](https://github.com/dsccommunity/DscResource.Common/issues/147)).
+- `Compare-DscParameterState`
+  - Added support for comparing large hashtables that contain lists of elements.
 
 ### Changed
 
+- `Assert-BoundParameter`
+  - Enhanced parameter `IfParameterPresent` to support both string arrays and
+    hashtables for conditional assertion logic.
+  - Added alias `IfEqualParameterList` to parameter `IfParameterPresent` for
+    backward compatibility.
 - `Get-ComputerName`
-  - Replaced platform-specific logic with cross-platform implementation using 
+  - Replaced platform-specific logic with cross-platform implementation using
     `[System.Environment]::MachineName` for consistent short name behavior.
-  - Enhanced FQDN functionality to use `[System.Net.Dns]::GetHostByName()` for 
+  - Enhanced FQDN functionality to use `[System.Net.Dns]::GetHostEntry()` for
     proper domain name resolution on Windows, Linux, and macOS.
-  - Improved error handling to gracefully fallback to short name when DNS 
+  - Improved error handling to gracefully fallback to short name when DNS
     resolution fails.
 
 ## [0.22.0] - 2025-04-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Chnaged
+
+- `Assert-BoundParameter`
+  - Enhanced parameter `IfParameterPresent` to support both string arrays and
+    hashtables for conditional assertion logic.
+  - Added alias `IfEqualParameterList` to parameter `IfParameterPresent` for
+    backward compatibility.
+
 ## [0.24.0] - 2025-08-26
 
 ### Added
@@ -24,11 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `Assert-BoundParameter`
-  - Enhanced parameter `IfParameterPresent` to support both string arrays and
-    hashtables for conditional assertion logic.
-  - Added alias `IfEqualParameterList` to parameter `IfParameterPresent` for
-    backward compatibility.
 - `Get-ComputerName`
   - Replaced platform-specific logic with cross-platform implementation using
     `[System.Environment]::MachineName` for consistent short name behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Chnaged
+### Changed
 
 - `Assert-BoundParameter`
   - Enhanced parameter `IfParameterPresent` to support both string arrays and

--- a/source/Private/Assert-RequiredCommandParameter.ps1
+++ b/source/Private/Assert-RequiredCommandParameter.ps1
@@ -26,7 +26,7 @@
         Throws an exception if either of the two parameters are not specified.
 
     .EXAMPLE
-        Assert-RequiredCommandParameter -BoundParameter $PSBoundParameters -RequiredParameter @('PBStartPortRange', 'PBEndPortRange') -RequiredBehavior 'AtLeastOnce'
+        Assert-RequiredCommandParameter -BoundParameter $PSBoundParameters -RequiredParameter @('PBStartPortRange', 'PBEndPortRange') -RequiredBehavior 'Any'
 
         Throws an exception if at least one of the two parameters are not specified.
 
@@ -84,7 +84,6 @@ function Assert-RequiredCommandParameter
                     {
                         $errorMessage = if ($PSBoundParameters.ContainsKey('IfParameterPresent'))
                         {
-
                             $script:localizedData.RequiredCommandParameter_SpecificParametersMustAllBeSetWhenParameterExist -f ($RequiredParameter -join ''', '''), ($IfParameterPresent -join ''', ''')
                         }
                         else
@@ -116,7 +115,6 @@ function Assert-RequiredCommandParameter
                 {
                     $errorMessage = if ($PSBoundParameters.ContainsKey('IfParameterPresent'))
                     {
-
                         $script:localizedData.RequiredCommandParameter_SpecificParametersAtLeastOneMustBeSetWhenParameterExist -f ($RequiredParameter -join ''', '''), ($IfParameterPresent -join ''', ''')
                     }
                     else
@@ -137,6 +135,5 @@ function Assert-RequiredCommandParameter
                 break
             }
         }
-
     }
 }

--- a/source/Public/Assert-BoundParameter.ps1
+++ b/source/Public/Assert-BoundParameter.ps1
@@ -161,6 +161,7 @@ function Assert-BoundParameter
         [Parameter(ParameterSetName = 'MutuallyExclusiveParameters')]
         [Parameter(ParameterSetName = 'AtLeastOne')]
         [Alias('IfEqualParameterList')]
+        [System.Object]
         $IfParameterPresent,
 
         [Parameter(ParameterSetName = 'AtLeastOne', Mandatory = $true)]

--- a/tests/Integration/Commands/Assert-BoundParameter.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Assert-BoundParameter.Integration.Tests.ps1
@@ -24,9 +24,9 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'DscResource.Common'
+    $script:moduleName = 'DscResource.Common'
 
-    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
 Describe 'Assert-BoundParameter Integration Tests' -Tag 'AssertBoundParameterIntegration' {

--- a/tests/Integration/Commands/Assert-BoundParameter.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Assert-BoundParameter.Integration.Tests.ps1
@@ -693,29 +693,6 @@ Describe 'Assert-BoundParameter Integration Tests' -Tag 'AssertBoundParameterInt
                         Assert-BoundParameter @assertBoundParameterParameters
                     } | Should -Not -Throw
                 }
-
-                It 'Should work with multiple conditions and IfParameterPresent together' {
-                    {
-                        $assertBoundParameterParameters = @{
-                            BoundParameterList   = @{
-                                ConfigType   = 'Advanced'
-                                Environment  = 'Production'
-                                TriggerParam = 'Present'
-                                Param1       = 'Value1'
-                                Param2       = 'Value2'
-                            }
-                            RequiredParameter    = @('Param1', 'Param2')
-                            IfParameterPresent   = @('TriggerParam')
-                            IfEqualParameterList = @{
-                                ConfigType  = 'Advanced'
-                                Environment = 'Production'
-                            }
-                            ErrorAction          = 'Stop'
-                        }
-
-                        Assert-BoundParameter @assertBoundParameterParameters
-                    } | Should -Not -Throw
-                }
             }
 
             Context 'When the IfEqualParameterList condition is not met' {

--- a/tests/Integration/Commands/Get-ComputerName.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-ComputerName.Integration.Tests.ps1
@@ -24,9 +24,9 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'DscResource.Common'
+    $script:moduleName = 'DscResource.Common'
 
-    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
 Describe 'Get-ComputerName' -Tag 'GetComputerName' {

--- a/tests/Integration/Commands/Set-DscMachineRebootRequired.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Set-DscMachineRebootRequired.Integration.Tests.ps1
@@ -24,9 +24,9 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'DscResource.Common'
+    $script:moduleName = 'DscResource.Common'
 
-    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
 Describe 'Set-DscMachineRebootRequired' -Tag 'Set-DscMachineRebootRequired' {

--- a/tests/Integration/Commands/Set-PSModulePath.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Set-PSModulePath.Integration.Tests.ps1
@@ -36,9 +36,9 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'DscResource.Common'
+    $script:moduleName = 'DscResource.Common'
 
-    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
 Describe 'Set-PSModulePath' -Tag 'SetPSModulePath' {

--- a/tests/Unit/Private/Assert-RequiredCommandParameter.Tests.ps1
+++ b/tests/Unit/Private/Assert-RequiredCommandParameter.Tests.ps1
@@ -29,7 +29,7 @@ BeforeAll {
     # Make sure there are not other modules imported that will conflict with mocks.
     Get-Module -Name $script:moduleName -All | Remove-Module -Force
 
-    Import-Module -Name $script:moduleName
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName

--- a/tests/Unit/Private/Assert-RequiredCommandParameter.Tests.ps1
+++ b/tests/Unit/Private/Assert-RequiredCommandParameter.Tests.ps1
@@ -144,7 +144,7 @@ Describe 'Assert-RequiredCommandParameter' -Tag 'Private' {
         }
 
         Context 'When the parameters in IfParameterPresent is present and required parameters are present' {
-            It 'Should throw the correct error' {
+            It 'Should not throw an error' {
                 InModuleScope -ScriptBlock {
                     Set-StrictMode -Version 1.0
 
@@ -240,7 +240,7 @@ Describe 'Assert-RequiredCommandParameter' -Tag 'Private' {
         }
 
         Context 'When the parameters in IfParameterPresent is present and one of the required parameters are present' {
-            It 'Should throw the correct error' {
+            It 'Should not throw an error' {
                 InModuleScope -ScriptBlock {
                     Set-StrictMode -Version 1.0
 

--- a/tests/Unit/Private/Clear-ZeroedEnumPropertyValue.Tests.ps1
+++ b/tests/Unit/Private/Clear-ZeroedEnumPropertyValue.Tests.ps1
@@ -29,7 +29,7 @@ BeforeAll {
     # Make sure there are not other modules imported that will conflict with mocks.
     Get-Module -Name $script:moduleName -All | Remove-Module -Force
 
-    Import-Module -Name $script:moduleName
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName

--- a/tests/Unit/Private/Test-DscPropertyIsAssigned.Tests.ps1
+++ b/tests/Unit/Private/Test-DscPropertyIsAssigned.Tests.ps1
@@ -26,7 +26,7 @@ BeforeDiscovery {
 BeforeAll {
     $script:dscModuleName = 'DscResource.Common'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Test-DscPropertyIsAssigned.Tests.ps1
+++ b/tests/Unit/Private/Test-DscPropertyIsAssigned.Tests.ps1
@@ -24,13 +24,13 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'DscResource.Common'
+    $script:moduleName = 'DscResource.Common'
 
     Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 
-    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
-    $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
-    $PSDefaultParameterValues['Should:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
 }
 
 AfterAll {
@@ -39,7 +39,7 @@ AfterAll {
     $PSDefaultParameterValues.Remove('Should:ModuleName')
 
     # Unload the module being tested so that it doesn't impact any other tests.
-    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
+    Get-Module -Name $script:moduleName -All | Remove-Module -Force
 }
 
 Describe 'Test-DscPropertyIsAssigned' -Tag 'Private' {

--- a/tests/Unit/Public/Assert-BoundParameter.Tests.ps1
+++ b/tests/Unit/Public/Assert-BoundParameter.Tests.ps1
@@ -314,9 +314,9 @@ Describe 'Assert-BoundParameter' -Tag 'AssertBoundParameter' {
         }
     }
 
-    Context 'When using IfEqualParameterList parameter' {
+    Context 'When using alias IfEqualParameterList parameter' {
         Context 'When using MutuallyExclusiveParameters parameter set' {
-            Context 'When the IfEqualParameterList condition is met' {
+            Context 'When the alias IfEqualParameterList condition is met' {
                 It 'Should throw an error when mutually exclusive parameters are both present' {
                     $errorMessage = InModuleScope -ScriptBlock {
                         $script:localizedData.ParameterUsageWrong
@@ -361,7 +361,7 @@ Describe 'Assert-BoundParameter' -Tag 'AssertBoundParameter' {
                 }
             }
 
-            Context 'When the IfEqualParameterList condition is not met' {
+            Context 'When the alias IfEqualParameterList condition is not met' {
                 It 'Should not throw an error even when mutually exclusive parameters are both present' {
                     {
                         $assertBoundParameterParameters = @{
@@ -400,7 +400,7 @@ Describe 'Assert-BoundParameter' -Tag 'AssertBoundParameter' {
                 }
             }
 
-            Context 'When multiple conditions in IfEqualParameterList must match' {
+            Context 'When multiple conditions in alias IfEqualParameterList must match' {
                 It 'Should throw an error when all conditions are met and mutually exclusive parameters are present' {
                     $errorMessage = InModuleScope -ScriptBlock {
                         $script:localizedData.ParameterUsageWrong
@@ -456,7 +456,7 @@ Describe 'Assert-BoundParameter' -Tag 'AssertBoundParameter' {
                 Mock -CommandName Assert-RequiredCommandParameter
             }
 
-            Context 'When the IfEqualParameterList condition is met' {
+            Context 'When the alias IfEqualParameterList condition is met' {
                 It 'Should call Assert-RequiredCommandParameter when condition is met' {
                     InModuleScope -ScriptBlock {
                         $testParams = @{
@@ -477,7 +477,7 @@ Describe 'Assert-BoundParameter' -Tag 'AssertBoundParameter' {
                 }
             }
 
-            Context 'When the IfEqualParameterList condition is not met' {
+            Context 'When the alias IfEqualParameterList condition is not met' {
                 It 'Should not call Assert-RequiredCommandParameter when condition is not met' {
                     InModuleScope -ScriptBlock {
                         $testParams = @{
@@ -497,10 +497,102 @@ Describe 'Assert-BoundParameter' -Tag 'AssertBoundParameter' {
                     Should -Invoke -CommandName Assert-RequiredCommandParameter -Exactly -Times 0 -Scope It
                 }
             }
+
+            Context 'When the IfParameterPresent condition is met using string value' {
+                It 'Should call Assert-RequiredCommandParameter when parameter is present' {
+                    InModuleScope -ScriptBlock {
+                        $testParams = @{
+                            BoundParameterList = @{
+                                Property1 = 'SomeValue'
+                                Property2 = 'Value2'
+                            }
+                            RequiredParameter = @('Property2', 'Property3')
+                            IfParameterPresent = 'Property1'
+                        }
+
+                        Assert-BoundParameter @testParams
+                    }
+
+                    Should -Invoke -CommandName Assert-RequiredCommandParameter -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Context 'When the IfParameterPresent condition is not met using string value' {
+                It 'Should not call Assert-RequiredCommandParameter when parameter is not present' {
+                    InModuleScope -ScriptBlock {
+                        $testParams = @{
+                            BoundParameterList = @{
+                                Property2 = 'Value2'
+                            }
+                            RequiredParameter = @('Property2', 'Property3')
+                            IfParameterPresent = 'Property1'
+                        }
+
+                        Assert-BoundParameter @testParams
+                    }
+
+                    Should -Invoke -CommandName Assert-RequiredCommandParameter -Exactly -Times 0 -Scope It
+                }
+            }
+
+            Context 'When the IfParameterPresent condition is met using string array with two items' {
+                It 'Should call Assert-RequiredCommandParameter when any parameter from array is present' {
+                    InModuleScope -ScriptBlock {
+                        $testParams = @{
+                            BoundParameterList = @{
+                                Property1 = 'SomeValue'
+                                Property3 = 'Value3'
+                            }
+                            RequiredParameter = @('Property3', 'Property4')
+                            IfParameterPresent = @('Property1', 'Property2')
+                        }
+
+                        Assert-BoundParameter @testParams
+                    }
+
+                    Should -Invoke -CommandName Assert-RequiredCommandParameter -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should call Assert-RequiredCommandParameter when second parameter from array is present' {
+                    InModuleScope -ScriptBlock {
+                        $testParams = @{
+                            BoundParameterList = @{
+                                Property2 = 'SomeValue'
+                                Property3 = 'Value3'
+                            }
+                            RequiredParameter = @('Property3', 'Property4')
+                            IfParameterPresent = @('Property1', 'Property2')
+                        }
+
+                        Assert-BoundParameter @testParams
+                    }
+
+                    Should -Invoke -CommandName Assert-RequiredCommandParameter -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Context 'When the IfParameterPresent condition is not met using string array with two items' {
+                It 'Should not call Assert-RequiredCommandParameter when none of the parameters from array are present' {
+                    InModuleScope -ScriptBlock {
+                        $testParams = @{
+                            BoundParameterList = @{
+                                Property3 = 'Value3'
+                                Property4 = 'Value4'
+                            }
+                            RequiredParameter = @('Property3', 'Property4')
+                            IfParameterPresent = @('Property1', 'Property2')
+                        }
+
+                        Assert-BoundParameter @testParams
+                    }
+
+                    Should -Invoke -CommandName Assert-RequiredCommandParameter -Exactly -Times 0 -Scope It
+                }
+            }
         }
 
         Context 'When using AtLeastOne parameter set' {
-            Context 'When the IfEqualParameterList condition is met' {
+            Context 'When the alias IfEqualParameterList condition is met' {
                 It 'Should throw an error when none of the required parameters are present' {
                     $errorMessage = InModuleScope -ScriptBlock {
                         $script:localizedData.Assert_BoundParameter_AtLeastOneParameterMustBeSet
@@ -542,7 +634,7 @@ Describe 'Assert-BoundParameter' -Tag 'AssertBoundParameter' {
                 }
             }
 
-            Context 'When the IfEqualParameterList condition is not met' {
+            Context 'When the alias IfEqualParameterList condition is not met' {
                 It 'Should not throw an error even when none of the required parameters are present' {
                     {
                         $assertBoundParameterParameters = @{

--- a/tests/Unit/Public/Assert-BoundParameter.Tests.ps1
+++ b/tests/Unit/Public/Assert-BoundParameter.Tests.ps1
@@ -50,17 +50,17 @@ Describe 'Assert-BoundParameter' -Tag 'AssertBoundParameter' {
         @{
             MockParameterSetName   = 'MutuallyExclusiveParameters'
             # cSpell: disable-next
-            MockExpectedParameters = '-BoundParameterList <hashtable> -MutuallyExclusiveList1 <string[]> -MutuallyExclusiveList2 <string[]> [-IfEqualParameterList <hashtable>] [<CommonParameters>]'
+            MockExpectedParameters = '-BoundParameterList <hashtable> -MutuallyExclusiveList1 <string[]> -MutuallyExclusiveList2 <string[]> [-IfParameterPresent <object>] [<CommonParameters>]'
         }
         @{
             MockParameterSetName   = 'RequiredParameter'
             # cSpell: disable-next
-            MockExpectedParameters = '-BoundParameterList <hashtable> -RequiredParameter <string[]> [-RequiredBehavior <BoundParameterBehavior>] [-IfParameterPresent <string[]>] [-IfEqualParameterList <hashtable>] [<CommonParameters>]'
+            MockExpectedParameters = '-BoundParameterList <hashtable> -RequiredParameter <string[]> [-RequiredBehavior <BoundParameterBehavior>] [-IfParameterPresent <object>] [<CommonParameters>]'
         }
         @{
             MockParameterSetName   = 'AtLeastOne'
             # cSpell: disable-next
-            MockExpectedParameters = '-BoundParameterList <hashtable> -AtLeastOneList <string[]> [-IfEqualParameterList <hashtable>] [<CommonParameters>]'
+            MockExpectedParameters = '-BoundParameterList <hashtable> -AtLeastOneList <string[]> [-IfParameterPresent <object>] [<CommonParameters>]'
         }
     ) {
         InModuleScope -Parameters $_ -ScriptBlock {


### PR DESCRIPTION

#### Pull Request (PR) description
- `Assert-BoundParameter`
  - Enhanced parameter `IfParameterPresent` to support both string arrays and
    hashtables for conditional assertion logic.
  - Added alias `IfEqualParameterList` to parameter `IfParameterPresent` for
    backward compatibility.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [x] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/DscResource.Common/165)
<!-- Reviewable:end -->
