### PR TITLE
Compare-DscParameterState: Fixed a bug comparing single-valued arrays in the desired state when TurnOffTypeChecking is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New-*Exception
   - Use `ThrowTerminatingError` instead of `throw`. Fixes [#177](https://github.com/dsccommunity/DscResource.Common/issues/177).
+- Compare-DscParameterState
+  - Fixed a bug comparing single-valued arrays in the desired state when
+    TurnOffTypeChecking is used [#184](https://github.com/dsccommunity/DscResource.Common/issues/184).
 
 ## [0.24.2] - 2025-08-27
 

--- a/source/Public/Compare-DscParameterState.ps1
+++ b/source/Public/Compare-DscParameterState.ps1
@@ -359,7 +359,7 @@ function Compare-DscParameterState
         }
         #endregion TestType
         #region Check if the value of Current and desired state is the same but only if they are not an array
-        if ($currentValue -eq $desiredValue -and -not $desiredType.IsArray)
+        if ($currentValue -eq $desiredValue -and -not $desiredType.IsArray -and -not $currentType.IsArray)
         {
             Write-Debug -Message ($script:localizedData.MatchValueMessage -f $desiredType.FullName, $key, $currentValue, $desiredValue)
             continue # pass to the next key

--- a/source/Public/Compare-DscParameterState.ps1
+++ b/source/Public/Compare-DscParameterState.ps1
@@ -650,7 +650,7 @@ function Compare-DscParameterState
         We use .foreach() method as we are sure that $returnValue is an array.
     #>
     [Array]$returnValue = @(
-        $returnValue.foreach(
+        $returnValue.ForEach(
             {
                 if ($_ -is [System.Collections.Hashtable])
                 {

--- a/tests/Unit/Public/Compare-DscParameterState.Tests.ps1
+++ b/tests/Unit/Public/Compare-DscParameterState.Tests.ps1
@@ -1258,6 +1258,7 @@ Describe 'DscResource.Common\Compare-DscParameterState' {
                 Bool      = $true
                 Int       = 99
                 Array     = 'a', 'b', 'c', 1
+                SingleValueArray = 'v1', 'v2' #for testing the comparison of single value arrays in the desired state
                 Hashtable = @{
                     k1 = 'Test'
                     k2 = 123
@@ -1511,6 +1512,41 @@ Describe 'DscResource.Common\Compare-DscParameterState' {
                 $script:result.Where({
                     $_.Property -ne 'Array'
                 }).InDesiredState | Should -Not -Contain $false
+            }
+        }
+
+        Context 'When there is a single-valued array and TurnOffTypeChecking is used' {
+            BeforeAll {
+                $desiredValues = [PSObject] @{
+                    String    = 'a string'
+                    Bool      = $true
+                    Int       = 99
+                    Array     = 'a', 'b', 'c', 1
+                    SingleValueArray = 'v1' #for testing the comparison of single value arrays in the desired state
+                    Hashtable = @{
+                        k1 = 'Test'
+                        k2 = 123
+                        k3 = 'v1', 'v2', 'v3'
+                    }
+                }
+            }
+
+            It 'Should not throw exception' {
+                { $script:result = Compare-DscParameterState `
+                        -CurrentValues $currentValues `
+                        -DesiredValues $desiredValues `
+                        -TurnOffTypeChecking `
+                        -Verbose:$verbose } | Should -Not -Throw
+            }
+
+            It 'Should not be null' {
+                $script:result | Should -Not -BeNullOrEmpty
+            }
+
+            It 'Should return $false for SingleValueArray InDesiredState' {
+                $script:result.Where({
+                    $_.Property -eq 'SingleValueArray'
+                }).InDesiredState | Should -BeFalse
             }
         }
 

--- a/tests/Unit/Public/Test-DscParameterState.Tests.ps1
+++ b/tests/Unit/Public/Test-DscParameterState.Tests.ps1
@@ -294,34 +294,6 @@ Describe 'Test-DscParameterState' {
             }
         }
 
-        Context 'When there is a single-valued array and TurnOffTypeChecking is used' {
-            BeforeAll {
-                $desiredValues = [PSObject] @{
-                    String = 'a string'
-                    Bool   = $true
-                    Int    = '99'
-                    Array  = 'a', 'b', 'c'
-                    SingleValueArray = 'v1' #Using a string by purpose to test single value array handling
-                }
-            }
-
-            It 'Should not throw exception' {
-                { Test-DscParameterState `
-                        -CurrentValues $currentValues `
-                        -DesiredValues $desiredValues `
-                        -TurnOffTypeChecking `
-                        -Verbose:$verbose } | Should -Not -Throw
-            }
-
-            It 'Should return $false' {
-                Test-DscParameterState `
-                    -CurrentValues $currentValues `
-                    -DesiredValues $desiredValues `
-                    -TurnOffTypeChecking `
-                    -Verbose:$verbose | Should -BeFalse
-            }
-        }
-
         Context 'When a value is mismatched but ExcludeProperties is used to exclude then' {
             BeforeAll {
                 $desiredValues = @{
@@ -621,14 +593,19 @@ Describe 'Test-DscParameterState' {
             }
         }
 
-        Context 'When an array in the desired state has one value and TurnOffTypeChecking is used' {
+         Context 'When there is a single-valued array and TurnOffTypeChecking is used' {
             BeforeAll {
                 $desiredValues = [PSObject] @{
-                    String = 'a string'
-                    Bool   = $true
-                    Int    = 99
-                    Array  = 'a', 'b', 'c', '1'
-                    SingleValueArray = 'v1'
+                    String    = 'a string'
+                    Bool      = $true
+                    Int       = 99
+                    Array     = 'a', 'b', 'c', 1
+                    SingleValueArray = 'v1' #for testing the comparison of single value arrays in the desired state
+                    Hashtable = @{
+                        k1 = 'Test'
+                        k2 = 123
+                        k3 = 'v1', 'v2', 'v3'
+                    }
                 }
             }
 
@@ -646,38 +623,6 @@ Describe 'Test-DscParameterState' {
                     -DesiredValues $desiredValues `
                     -TurnOffTypeChecking `
                     -Verbose:$verbose | Should -BeFalse
-            }
-        }
-
-        Context 'When an array in hashtable has different order but SortArrayValues is used' {
-            BeforeAll {
-                $desiredValues = [PSObject] @{
-                    String    = 'a string'
-                    Bool      = $true
-                    Int       = 99
-                    Array     = 'a', 'b', 'c'
-                    Hashtable = @{
-                        k1 = 'Test'
-                        k2 = 123
-                        k3 = 'v3', 'v2', 'v1', 99
-                    }
-                }
-            }
-
-            It 'Should not throw exception' {
-                { Test-DscParameterState `
-                        -CurrentValues $currentValues `
-                        -DesiredValues $desiredValues `
-                        -SortArrayValues `
-                        -Verbose:$verbose } | Should -Not -Throw
-            }
-
-            It 'Should return $true' {
-                Test-DscParameterState `
-                    -CurrentValues $currentValues `
-                    -DesiredValues $desiredValues `
-                    -SortArrayValues `
-                    -Verbose:$verbose | Should -BeTrue
             }
         }
 

--- a/tests/Unit/Public/Test-DscParameterState.Tests.ps1
+++ b/tests/Unit/Public/Test-DscParameterState.Tests.ps1
@@ -569,7 +569,6 @@ Describe 'Test-DscParameterState' {
             }
         }
 
-
         Context 'When array has a value with a different type' {
             BeforeAll {
                 $desiredValues = [PSObject] @{
@@ -618,6 +617,38 @@ Describe 'Test-DscParameterState' {
                     -CurrentValues $currentValues `
                     -DesiredValues $desiredValues `
                     -TurnOffTypeChecking `
+                    -Verbose:$verbose | Should -BeTrue
+            }
+        }
+
+        Context 'When an array in hashtable has different order but SortArrayValues is used' {
+            BeforeAll {
+                $desiredValues = [PSObject] @{
+                    String    = 'a string'
+                    Bool      = $true
+                    Int       = 99
+                    Array     = 'a', 'b', 'c'
+                    Hashtable = @{
+                        k1 = 'Test'
+                        k2 = 123
+                        k3 = 'v3', 'v2', 'v1', 99
+                    }
+                }
+            }
+
+            It 'Should not throw exception' {
+                { Test-DscParameterState `
+                        -CurrentValues $currentValues `
+                        -DesiredValues $desiredValues `
+                        -SortArrayValues `
+                        -Verbose:$verbose } | Should -Not -Throw
+            }
+
+            It 'Should return $true' {
+                Test-DscParameterState `
+                    -CurrentValues $currentValues `
+                    -DesiredValues $desiredValues `
+                    -SortArrayValues `
                     -Verbose:$verbose | Should -BeTrue
             }
         }
@@ -877,39 +908,6 @@ Describe 'Test-DscParameterState' {
                     -Verbose:$verbose | Should -BeFalse
             }
         }
-
-        Context 'When an array in hashtable has different order but SortArrayValues is used' {
-            BeforeAll {
-                $desiredValues = [PSObject] @{
-                    String    = 'a string'
-                    Bool      = $true
-                    Int       = 99
-                    Array     = 'a', 'b', 'c'
-                    Hashtable = @{
-                        k1 = 'Test'
-                        k2 = 123
-                        k3 = 'v3', 'v2', 'v1', 99
-                    }
-                }
-            }
-
-            It 'Should not throw exception' {
-                { Test-DscParameterState `
-                        -CurrentValues $currentValues `
-                        -DesiredValues $desiredValues `
-                        -SortArrayValues `
-                        -Verbose:$verbose } | Should -Not -Throw
-            }
-
-            It 'Should return $true' {
-                Test-DscParameterState `
-                    -CurrentValues $currentValues `
-                    -DesiredValues $desiredValues `
-                    -SortArrayValues `
-                    -Verbose:$verbose | Should -BeTrue
-            }
-        }
-
 
         Context 'When hashtable has a value with a different type' {
             BeforeAll {

--- a/tests/Unit/Public/Test-DscParameterState.Tests.ps1
+++ b/tests/Unit/Public/Test-DscParameterState.Tests.ps1
@@ -975,8 +975,8 @@ Describe 'Test-DscParameterState' {
 
         Context 'When an array in the desired state has one value and TurnOffTypeChecking is used' {
             BeforeAll {
-                    String = 'a string'
                 $desiredValues = [PSObject] @{
+                    String = 'a string'
                     Bool   = $true
                     Int    = 99
                     Array  = 'a', 'b', 'c', '1'

--- a/tests/Unit/Public/Test-DscParameterState.Tests.ps1
+++ b/tests/Unit/Public/Test-DscParameterState.Tests.ps1
@@ -294,6 +294,34 @@ Describe 'Test-DscParameterState' {
             }
         }
 
+        Context 'When there is a single-valued array and TurnOffTypeChecking is used' {
+            BeforeAll {
+                $desiredValues = [PSObject] @{
+                    String = 'a string'
+                    Bool   = $true
+                    Int    = '99'
+                    Array  = 'a', 'b', 'c'
+                    SingleValueArray = 'v1' #Using a string by purpose to test single value array handling
+                }
+            }
+
+            It 'Should not throw exception' {
+                { Test-DscParameterState `
+                        -CurrentValues $currentValues `
+                        -DesiredValues $desiredValues `
+                        -TurnOffTypeChecking `
+                        -Verbose:$verbose } | Should -Not -Throw
+            }
+
+            It 'Should return $false' {
+                Test-DscParameterState `
+                    -CurrentValues $currentValues `
+                    -DesiredValues $desiredValues `
+                    -TurnOffTypeChecking `
+                    -Verbose:$verbose | Should -BeFalse
+            }
+        }
+
         Context 'When a value is mismatched but ExcludeProperties is used to exclude then' {
             BeforeAll {
                 $desiredValues = @{
@@ -400,6 +428,7 @@ Describe 'Test-DscParameterState' {
                 Bool      = $true
                 Int       = 99
                 Array     = 'a', 'b', 'c', 1
+                SingleValueArray = 'v1', 'v2' #for testing the comparison of single value arrays in the desired state
                 Hashtable = @{
                     k1 = 'Test'
                     k2 = 123
@@ -941,6 +970,34 @@ Describe 'Test-DscParameterState' {
                     -DesiredValues $desiredValues `
                     -TurnOffTypeChecking `
                     -Verbose:$verbose | Should -BeTrue
+            }
+        }
+
+        Context 'When an array in the desired state has one value and TurnOffTypeChecking is used' {
+            BeforeAll {
+                    String = 'a string'
+                $desiredValues = [PSObject] @{
+                    Bool   = $true
+                    Int    = 99
+                    Array  = 'a', 'b', 'c', '1'
+                    SingleValueArray = 'v1'
+                }
+            }
+
+            It 'Should not throw exception' {
+                { Test-DscParameterState `
+                        -CurrentValues $currentValues `
+                        -DesiredValues $desiredValues `
+                        -TurnOffTypeChecking `
+                        -Verbose:$verbose } | Should -Not -Throw
+            }
+
+            It 'Should return $false' {
+                Test-DscParameterState `
+                    -CurrentValues $currentValues `
+                    -DesiredValues $desiredValues `
+                    -TurnOffTypeChecking `
+                    -Verbose:$verbose | Should -BeFalse
             }
         }
     }

--- a/tests/Unit/Public/Test-DscParameterState.Tests.ps1
+++ b/tests/Unit/Public/Test-DscParameterState.Tests.ps1
@@ -621,6 +621,34 @@ Describe 'Test-DscParameterState' {
             }
         }
 
+        Context 'When an array in the desired state has one value and TurnOffTypeChecking is used' {
+            BeforeAll {
+                $desiredValues = [PSObject] @{
+                    String = 'a string'
+                    Bool   = $true
+                    Int    = 99
+                    Array  = 'a', 'b', 'c', '1'
+                    SingleValueArray = 'v1'
+                }
+            }
+
+            It 'Should not throw exception' {
+                { Test-DscParameterState `
+                        -CurrentValues $currentValues `
+                        -DesiredValues $desiredValues `
+                        -TurnOffTypeChecking `
+                        -Verbose:$verbose } | Should -Not -Throw
+            }
+
+            It 'Should return $false' {
+                Test-DscParameterState `
+                    -CurrentValues $currentValues `
+                    -DesiredValues $desiredValues `
+                    -TurnOffTypeChecking `
+                    -Verbose:$verbose | Should -BeFalse
+            }
+        }
+
         Context 'When an array in hashtable has different order but SortArrayValues is used' {
             BeforeAll {
                 $desiredValues = [PSObject] @{
@@ -968,34 +996,6 @@ Describe 'Test-DscParameterState' {
                     -DesiredValues $desiredValues `
                     -TurnOffTypeChecking `
                     -Verbose:$verbose | Should -BeTrue
-            }
-        }
-
-        Context 'When an array in the desired state has one value and TurnOffTypeChecking is used' {
-            BeforeAll {
-                $desiredValues = [PSObject] @{
-                    String = 'a string'
-                    Bool   = $true
-                    Int    = 99
-                    Array  = 'a', 'b', 'c', '1'
-                    SingleValueArray = 'v1'
-                }
-            }
-
-            It 'Should not throw exception' {
-                { Test-DscParameterState `
-                        -CurrentValues $currentValues `
-                        -DesiredValues $desiredValues `
-                        -TurnOffTypeChecking `
-                        -Verbose:$verbose } | Should -Not -Throw
-            }
-
-            It 'Should return $false' {
-                Test-DscParameterState `
-                    -CurrentValues $currentValues `
-                    -DesiredValues $desiredValues `
-                    -TurnOffTypeChecking `
-                    -Verbose:$verbose | Should -BeFalse
             }
         }
     }


### PR DESCRIPTION
#### Pull Request (PR) description

Compare-DscParameterState: Fixed a bug comparing single-valued arrays in the desired state when TurnOffTypeChecking is used

#### This Pull Request (PR) fixes the following issues

    - Fixes #184

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/DscResource.Common/185)
<!-- Reviewable:end -->
